### PR TITLE
Handle Whoosh schema migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ make reindex-incremental
 make tail               # follow the focused crawl log in another terminal
 ```
 
+### Index schema upgrades
+
+The incremental indexer now validates the on-disk Whoosh schema before reusing it. If a legacy deployment only contains the
+`text`, `title`, and `url` fields, the index directory is automatically rebuilt so the modern `url`, `lang`, `title`, `h1h2`, and
+`body` fields are available. Existing postings are discarded during this migration, so plan to re-run your crawl or the
+incremental indexer afterwards to repopulate the upgraded schema.
+
 Run CLI searches straight from your terminal:
 
 ```bash

--- a/tests/test_index_schema_upgrade.py
+++ b/tests/test_index_schema_upgrade.py
@@ -1,0 +1,36 @@
+from whoosh import index
+from whoosh.fields import ID, TEXT, Schema
+
+from backend.app.indexer.incremental import ensure_index, REQUIRED_FIELDS
+
+
+def test_ensure_index_upgrades_legacy_schema(tmp_path):
+    index_dir = tmp_path / "legacy_index"
+    index_dir.mkdir()
+
+    legacy_schema = Schema(
+        url=ID(stored=True, unique=True),
+        title=TEXT(stored=True),
+        text=TEXT(stored=True),
+    )
+    legacy_ix = index.create_in(index_dir, legacy_schema)
+    writer = legacy_ix.writer()
+    writer.commit()
+    legacy_ix.close()
+
+    upgraded_ix = ensure_index(index_dir)
+    try:
+        names = set(upgraded_ix.schema.names())
+        assert REQUIRED_FIELDS.issubset(names)
+
+        writer = upgraded_ix.writer()
+        writer.add_document(
+            url="https://example.com/",
+            lang="en",
+            title="Example Title",
+            h1h2="Example Heading",
+            body="Body text for schema upgrade test.",
+        )
+        writer.commit()
+    finally:
+        upgraded_ix.close()


### PR DESCRIPTION
## Summary
- validate the existing Whoosh index schema before reuse and rebuild when required fields are missing or incompatible
- log migrations, recreate the index directory with the current schema, and document the behavior for operators
- cover the automatic upgrade path with a regression test that exercises a legacy index layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ccc7982b6083218343d0f23ee89844