### PR TITLE
Fix Makefile recipes with tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ normalize:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/normalize.py'
 
 reindex-incremental:
-        @bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/reindex_incremental.py'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/reindex_incremental.py'
 
 seeds:
-        @bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/seeds_prepare.py'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/seeds_prepare.py'
 
 index-inc:
-        @bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/index_inc.py --once'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/index_inc.py --once'
 
 tail:
 	@if [ -z "$$JOB" ]; then echo "Set JOB=<identifier> to tail" >&2; exit 1; fi


### PR DESCRIPTION
## Summary
- replace the space-indented recipes for the reindex-incremental, seeds, and index-inc targets with tab-indented commands so GNU Make executes them

## Testing
- make setup
- make dev

------
https://chatgpt.com/codex/tasks/task_e_68cee16701dc832183b58d46a182f0ef