### PR TITLE
Add Chroma-backed vector store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pytest.ini
 *.egg-info/
 *.zst
 data/
+!engine/data/
 .chroma/
 index/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ A quick smoke check is available too:
 pytest -q
 ```
 
+## RAG vector store configuration
+
+The retrieval layer persists embeddings in a local [Chroma](https://www.trychroma.com/) store and tracks crawl metadata in DuckDB. Both paths are configurable via `config.yaml`:
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `index.persist_dir` | `./.chroma` | Directory holding the Chroma collection used during retrieval |
+| `index.db_path` | `./data/index.duckdb` | DuckDB database storing document metadata for crawl deduplication |
+
+Ensure these locations live on fast local storage—the cold-start indexer and Flask app share the same files, so the vector store must be accessible to both processes.
+
 ## Crawl → Index → Search
 
 Seed the crawler with either a single URL or a seeds file:

--- a/engine/data/__init__.py
+++ b/engine/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data layer for retrieval embeddings."""
+
+from .store import RetrievedChunk, VectorStore
+
+__all__ = ["RetrievedChunk", "VectorStore"]

--- a/engine/data/store.py
+++ b/engine/data/store.py
@@ -1,0 +1,199 @@
+"""Persistent vector store built on Chroma + DuckDB."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+import hashlib
+import threading
+
+import duckdb
+from chromadb import PersistentClient
+from chromadb.api.models.Collection import Collection
+from chromadb.config import Settings
+
+from ..indexing.chunk import Chunk
+
+
+@dataclass(slots=True)
+class RetrievedChunk:
+    """Represents a chunk returned from the vector store."""
+
+    text: str
+    title: str | None
+    url: str | None
+    similarity: float
+
+
+class VectorStore:
+    """Lightweight wrapper around Chroma for RAG retrieval."""
+
+    _COLLECTION_NAME = "rag_documents"
+    _client_cache: dict[Path, PersistentClient] = {}
+    _collection_cache: dict[Path, Collection] = {}
+    _cache_lock = threading.Lock()
+
+    def __init__(self, persist_dir: str | Path, db_path: str | Path) -> None:
+        self._persist_dir = Path(persist_dir).resolve()
+        self._db_path = Path(db_path).resolve()
+        self._persist_dir.mkdir(parents=True, exist_ok=True)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._collection = self._get_collection(self._persist_dir)
+        self._collection_lock = threading.Lock()
+        self._initialize_db()
+
+    @classmethod
+    def _get_collection(cls, persist_dir: Path) -> Collection:
+        key = persist_dir
+        with cls._cache_lock:
+            collection = cls._collection_cache.get(key)
+            if collection is not None:
+                return collection
+            client = cls._client_cache.get(key)
+            if client is None:
+                client = PersistentClient(
+                    path=str(persist_dir),
+                    settings=Settings(
+                        anonymized_telemetry=False,
+                        allow_reset=True,
+                        is_persistent=True,
+                    ),
+                )
+                cls._client_cache[key] = client
+            collection = client.get_or_create_collection(
+                cls._COLLECTION_NAME, metadata={"hnsw:space": "cosine"}
+            )
+            cls._collection_cache[key] = collection
+            return collection
+
+    def _initialize_db(self) -> None:
+        with duckdb.connect(str(self._db_path)) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS documents (
+                    url TEXT PRIMARY KEY,
+                    title TEXT,
+                    etag TEXT,
+                    content_hash TEXT,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+    @staticmethod
+    def _chunk_id(url: str, index: int) -> str:
+        digest = hashlib.sha1(f"{url}::{index}".encode("utf-8"), usedforsecurity=False)
+        return digest.hexdigest()
+
+    @staticmethod
+    def _ensure_embedding(vector: Sequence[float]) -> list[float]:
+        return [float(value) for value in vector]
+
+    def needs_update(self, url: str, etag: str | None, content_hash: str) -> bool:
+        with duckdb.connect(str(self._db_path)) as conn:
+            row = conn.execute(
+                "SELECT etag, content_hash FROM documents WHERE url = ?", (url,)
+            ).fetchone()
+        if row is None:
+            return True
+        stored_etag, stored_hash = row
+        if stored_hash is not None and stored_hash == content_hash:
+            return False
+        if (
+            stored_hash in (None, "")
+            and etag is not None
+            and stored_etag is not None
+            and stored_etag == etag
+        ):
+            return False
+        return True
+
+    def upsert(
+        self,
+        url: str,
+        title: str,
+        etag: str | None,
+        content_hash: str,
+        chunks: Sequence[Chunk],
+        embeddings: Sequence[Sequence[float]],
+    ) -> None:
+        if len(chunks) != len(embeddings):
+            raise ValueError("chunks and embeddings must have the same length")
+
+        with duckdb.connect(str(self._db_path)) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO documents (url, title, etag, content_hash, updated_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """,
+                (url, title, etag, content_hash),
+            )
+
+        with self._collection_lock:
+            self._collection.delete(where={"url": url})
+            if not chunks:
+                return
+            documents = [chunk.text for chunk in chunks]
+            metadatas = [
+                {
+                    "url": url,
+                    "title": title,
+                    "chunk_index": idx,
+                    "start": chunk.start,
+                    "end": chunk.end,
+                    "token_count": chunk.token_count,
+                    "etag": etag,
+                    "content_hash": content_hash,
+                }
+                for idx, chunk in enumerate(chunks)
+            ]
+            ids = [self._chunk_id(url, idx) for idx in range(len(chunks))]
+            embedding_list = [self._ensure_embedding(embedding) for embedding in embeddings]
+            self._collection.add(
+                ids=ids,
+                documents=documents,
+                metadatas=metadatas,
+                embeddings=embedding_list,
+            )
+
+    def query(
+        self, vector: Sequence[float], k: int, similarity_threshold: float
+    ) -> list[RetrievedChunk]:
+        if k <= 0:
+            return []
+        if not vector:
+            return []
+        query_embedding = [self._ensure_embedding(vector)]
+        with self._collection_lock:
+            results = self._collection.query(
+                query_embeddings=query_embedding,
+                n_results=k,
+                include=["metadatas", "documents", "distances"],
+            )
+        ids = results.get("ids") or []
+        if not ids:
+            return []
+        documents = results.get("documents", [[]])[0] or []
+        metadatas = results.get("metadatas", [[]])[0] or []
+        distances = results.get("distances", [[]])[0] or []
+        retrieved: list[RetrievedChunk] = []
+        for document, metadata, distance in zip(documents, metadatas, distances):
+            if document is None or metadata is None:
+                continue
+            similarity = 1.0 - float(distance) if distance is not None else 0.0
+            if similarity < similarity_threshold:
+                continue
+            retrieved.append(
+                RetrievedChunk(
+                    text=document,
+                    title=metadata.get("title"),
+                    url=metadata.get("url"),
+                    similarity=similarity,
+                )
+            )
+        retrieved.sort(key=lambda chunk: chunk.similarity, reverse=True)
+        return retrieved[:k]
+
+
+__all__ = ["VectorStore", "RetrievedChunk"]

--- a/tests/engine/test_vector_store.py
+++ b/tests/engine/test_vector_store.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import hashlib
+
+from engine.data.store import RetrievedChunk, VectorStore
+from engine.indexing.chunk import Chunk
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_vector_store_round_trip(tmp_path):
+    persist_dir = tmp_path / "chroma"
+    db_path = tmp_path / "index.duckdb"
+    store = VectorStore(persist_dir, db_path)
+
+    url = "https://example.com/article"
+    title = "Example"
+    etag = "W/\"12345\""
+    content = "This is a retrieved chunk"
+    content_hash = _hash(content)
+
+    assert store.needs_update(url, etag, content_hash) is True
+
+    chunk = Chunk(text=content, start=0, end=len(content), token_count=5)
+    embedding = [0.1, 0.2, 0.3]
+    store.upsert(url, title, etag, content_hash, [chunk], [embedding])
+
+    assert store.needs_update(url, etag, content_hash) is False
+    assert store.needs_update(url, None, content_hash) is False
+    assert store.needs_update(url, etag, _hash(content + "!")) is True
+
+    results = store.query(embedding, k=3, similarity_threshold=0.5)
+    assert len(results) == 1
+    retrieved = results[0]
+    assert isinstance(retrieved, RetrievedChunk)
+    assert retrieved.text == content
+    assert retrieved.title == title
+    assert retrieved.url == url
+    assert retrieved.similarity >= 0.99


### PR DESCRIPTION
## Summary
- restore the engine.data package with a RetrievedChunk dataclass for RAG responses
- implement a Chroma + DuckDB backed VectorStore with thread-safe client caching and metadata dedupe helpers
- document vector store settings and add a smoke test covering needs_update, upsert, and query round-trips

## Testing
- pytest tests/engine/test_vector_store.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d0741a5dac8321b18c6ab3d17f67fe