### PR TITLE
Update default embedding model to EmbeddingGemma

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 models:
   llm_primary: "gemma2:latest"
   llm_fallback: "gpt-oss:latest"
-  embed: "nomic-embed-text"
+  embed: "embedding-gemma:7b"
 ollama:
   base_url: "http://localhost:11434"
 retrieval:

--- a/engine/config.py
+++ b/engine/config.py
@@ -71,7 +71,7 @@ class EngineConfig:
         model_cfg = ModelConfig(
             llm_primary=str(models.get("llm_primary", "gemma2:latest")),
             llm_fallback=str(models.get("llm_fallback")) if models.get("llm_fallback") else None,
-            embed=str(models.get("embed", "nomic-embed-text")),
+            embed=str(models.get("embed", "embedding-gemma:7b")),
         )
         ollama_cfg = OllamaConfig(base_url=str(ollama.get("base_url", "http://localhost:11434")))
         retrieval_cfg = RetrievalConfig(


### PR DESCRIPTION
## Summary
- change the default embedding model in `config.yaml` to `embedding-gemma:7b`
- align the fallback default in `engine/config.py` with the new EmbeddingGemma tag

## Testing
- `pytest tests/api/test_search_api.py::test_search_reports_embedding_unavailable -q`

------
https://chatgpt.com/codex/tasks/task_e_68d08634800083218bd8d783a3c34d7e