### PR TITLE
Set embeddinggemma as primary embedding model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ SMART_MIN_RESULTS=1
 SMART_TRIGGER_COOLDOWN=900
 OLLAMA_URL=http://127.0.0.1:11434
 OLLAMA_BASE_URL=http://127.0.0.1:11434
+# Embedding defaults: auto-install the canonical embeddinggemma model unless you override it.
+# If the pull hangs, check free disk space and network access to https://registry.ollama.ai, or run
+# `ollama pull embeddinggemma` manually before retrying.
 EMBED_MODEL=embeddinggemma
 EMBED_AUTO_INSTALL=true
 EMBED_FALLBACKS=nomic-embed-text,gte-small

--- a/README.md
+++ b/README.md
@@ -124,22 +124,25 @@ ollama serve
 ollama pull llama3.1:8b-instruct
 ```
 
-The semantic search stack now bootstraps embeddings automatically. On the first search request the Flask backend checks for the canonical `embeddinggemma` model, streams `ollama pull` progress to the browser, and queues concurrent queries until the model is ready. Manual preparation is still a single command:
+### Embedding model defaults
 
-```bash
-ollama pull embeddinggemma
-```
+- The backend now targets the canonical `embeddinggemma` model. On the first semantic search the Flask API checks whether the model exists locally, streams the `ollama pull` progress to the UI, and queues concurrent queries until embeddings are available.
+- Manual preparation is still a single command if you prefer to pull models yourself:
 
-Configure overrides through environment variables when needed:
+  ```bash
+  ollama pull embeddinggemma
+  ```
 
-- `EMBED_MODEL` – alternate embedding model name (defaults to `embeddinggemma`).
-- `EMBED_AUTO_INSTALL` – set to `false` to disable automatic pulls.
-- `EMBED_FALLBACKS` – comma-separated list of fallback embedding models (`nomic-embed-text,gte-small` by default).
+- Configure overrides through environment variables when needed:
 
-Troubleshooting tips:
+  - `EMBED_MODEL` – alternate embedding model name (defaults to `embeddinggemma`).
+  - `EMBED_AUTO_INSTALL` – set to `false` to disable automatic pulls.
+  - `EMBED_FALLBACKS` – comma-separated list of fallback embedding models (`nomic-embed-text,gte-small` by default).
+
+Troubleshooting tips when the auto-install flow stalls:
 
 - **Disk space** – Ollama needs several GB free before it can unpack models. Clear older models with `ollama rm <name>` if the pull fails with `no space left on device`.
-- **Network stalls** – the UI exposes a retry button and fallback picker. Ensure the host can reach `https://registry.ollama.ai` or pre-download the model and import it into the Ollama cache.
+- **Network stalls** – ensure the host can reach `https://registry.ollama.ai`. The UI exposes a retry button and fallback picker, or you can pre-download/import the model into the Ollama cache.
 - **Runtime offline** – the “Start Ollama” button issues `brew services start ollama`/`systemctl start ollama` depending on the platform and surfaces errors when the daemon stays offline.
 
 Once the embedding model is present and `ollama serve` is running, `/api/search` responses return to `200` and repeat queries reuse the local cache immediately.

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 models:
   llm_primary: "gemma2:latest"
   llm_fallback: "gpt-oss:latest"
-  embed: "embedding-gemma:7b"
+  embed: "embeddinggemma"
 ollama:
   base_url: "http://localhost:11434"
 retrieval:

--- a/engine/config.py
+++ b/engine/config.py
@@ -71,7 +71,7 @@ class EngineConfig:
         model_cfg = ModelConfig(
             llm_primary=str(models.get("llm_primary", "gemma2:latest")),
             llm_fallback=str(models.get("llm_fallback")) if models.get("llm_fallback") else None,
-            embed=str(models.get("embed", "embedding-gemma:7b")),
+            embed=str(models.get("embed", "embeddinggemma")),
         )
         ollama_cfg = OllamaConfig(base_url=str(ollama.get("base_url", "http://localhost:11434")))
         retrieval_cfg = RetrievalConfig(


### PR DESCRIPTION
## Summary
- set the engine and sample config to default to the `embeddinggemma` embedding model
- document the auto-install workflow, manual `ollama pull` command, and troubleshooting guidance in the README and `.env.example`

## Testing
- pytest tests/test_embedding_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a8adeb2c8321a17a99be63b158b0