### PR TITLE
Add telemetry shim with local logging support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,13 @@
 # Copy to .env and adjust as needed.
 
+# Runtime environment
+APP_ENV=development
+# Leave TELEMETRY_ENABLED unset to follow the environment defaults
+# (development disables telemetry). Set to 1 to force-enable in staging/production.
+TELEMETRY_ENABLED=
+# Set to 1 to append JSON events to /tmp/telemetry.log for local debugging.
+TELEMETRY_LOG_LOCAL=
+
 # Core storage paths
 DATA_DIR=./data
 INDEX_DIR=./data/index

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Export variables via `.env` (auto-loaded by `make` targets) or the shell:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
+| `APP_ENV` | `development` | Controls environment-specific behaviour such as telemetry defaults |
+| `TELEMETRY_ENABLED` | _(auto)_ | Override to force telemetry on/off (`1`/`0`); defaults to disabled in development |
+| `TELEMETRY_LOG_LOCAL` | _(empty)_ | When set, append JSONL telemetry events to `/tmp/telemetry.log` |
 | `INDEX_DIR` | `./data/index` | Location of the Whoosh index |
 | `CRAWL_STORE` | `./data/crawl` | Where crawler JSONL data is persisted |
 | `CRAWL_MAX_PAGES` | `100` | Stop after visiting this many pages |

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -1,0 +1,125 @@
+"""Lightweight telemetry shim with optional local logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any, Mapping
+
+__all__ = ["capture"]
+
+_LOGGER = logging.getLogger(__name__)
+_LOG_PATH = Path("/tmp/telemetry.log")
+_LOG_LOCK = Lock()
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_DEV_ENVS = {"development", "dev", "local"}
+
+
+def _normalize_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    lowered = value.strip().lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    return None
+
+
+def _app_env() -> str:
+    env = os.getenv("APP_ENV", "development").strip()
+    return env or "development"
+
+
+def _is_dev() -> bool:
+    return _app_env().lower() in _DEV_ENVS
+
+
+def _telemetry_enabled() -> bool:
+    override = _normalize_bool(os.getenv("TELEMETRY_ENABLED"))
+    if override is not None:
+        return override
+    return not _is_dev()
+
+
+def _should_log_local() -> bool:
+    return bool(_normalize_bool(os.getenv("TELEMETRY_LOG_LOCAL")))
+
+
+def _merge_properties(
+    props: Mapping[str, Any] | None, extra: Mapping[str, Any]
+) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    if props:
+        for key, value in props.items():
+            if isinstance(key, str) and key:
+                merged[key] = value
+    for key, value in extra.items():
+        if isinstance(key, str) and key:
+            merged[key] = value
+    return merged
+
+
+def _write_local_log(event: str, properties: Mapping[str, Any]) -> None:
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "properties": dict(properties),
+    }
+    line = json.dumps(payload, ensure_ascii=False)
+    with _LOG_LOCK:
+        _LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _LOG_PATH.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def _emit_event(event: str, properties: Mapping[str, Any]) -> None:
+    """Hook for dispatching telemetry to a remote backend.
+
+    The default implementation is a no-op so deployments without
+    telemetry dependencies stay silent. Tests or runtime code can
+    monkeypatch this function to integrate with a real provider.
+    """
+
+
+def capture(
+    event_name: str, props: Mapping[str, Any] | None = None, **kwargs: Any
+) -> bool:
+    """Record a telemetry event if enabled.
+
+    Returns ``True`` when the event was processed (either dispatched
+    remotely or logged locally). Always swallows errors when running in
+    development to avoid noisy stack traces.
+    """
+
+    if not isinstance(event_name, str):
+        return False
+    event = event_name.strip()
+    if not event:
+        return False
+
+    properties = _merge_properties(props, kwargs)
+
+    should_log = _should_log_local()
+    enabled = _telemetry_enabled()
+
+    if not should_log and not enabled:
+        return False
+
+    try:
+        if should_log:
+            _write_local_log(event, properties)
+        if enabled:
+            _emit_event(event, properties)
+        return True
+    except Exception:  # pragma: no cover - defensive logging path
+        if _is_dev():
+            return False
+        _LOGGER.warning("Failed to capture telemetry event '%s'", event, exc_info=True)
+        return False

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.app import telemetry
+
+
+LOG_PATH = Path("/tmp/telemetry.log")
+
+
+def _reset_log() -> None:
+    if LOG_PATH.exists():
+        LOG_PATH.unlink()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_capture_dev_mode_is_silent(monkeypatch):
+    _reset_log()
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
+    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
+
+    def _should_not_run(event: str, props):  # pragma: no cover - guard
+        raise AssertionError("_emit_event should not be called in dev mode")
+
+    monkeypatch.setattr(telemetry, "_emit_event", _should_not_run)
+    assert telemetry.capture("dev-test", {"foo": "bar"}) is False
+    assert not LOG_PATH.exists()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_capture_dev_mode_logs_locally(monkeypatch):
+    _reset_log()
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("TELEMETRY_LOG_LOCAL", "1")
+    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
+
+    assert telemetry.capture("dev-local", {"key": "value"}, extra=123) is True
+    assert LOG_PATH.exists()
+
+    last_line = LOG_PATH.read_text("utf-8").strip().splitlines()[-1]
+    payload = json.loads(last_line)
+    assert payload["event"] == "dev-local"
+    assert payload["properties"] == {"key": "value", "extra": 123}
+
+    _reset_log()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_capture_production_invokes_emitter(monkeypatch):
+    _reset_log()
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
+    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
+
+    recorded: list[tuple[str, dict]] = []
+
+    def _capture(event: str, props):
+        recorded.append((event, dict(props)))
+
+    monkeypatch.setattr(telemetry, "_emit_event", _capture)
+
+    assert telemetry.capture("prod-event", foo="bar") is True
+    assert recorded == [("prod-event", {"foo": "bar"})]
+    assert not LOG_PATH.exists()
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_capture_production_swallows_errors(monkeypatch, caplog):
+    _reset_log()
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
+    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
+
+    def _boom(event: str, props):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(telemetry, "_emit_event", _boom)
+
+    with caplog.at_level("WARNING"):
+        assert telemetry.capture("prod-error") is False
+
+    assert "Failed to capture telemetry event" in caplog.text
+    assert not LOG_PATH.exists()


### PR DESCRIPTION
## Summary
- add a backend telemetry shim that gates event dispatching via APP_ENV/TELEMETRY_ENABLED and supports optional local JSONL logging
- document the new telemetry environment flags in `.env.example` and the README
- exercise the telemetry shim with pytest coverage for development vs production behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d0bac09dd8832183cdf50a6a9d1d31