### PR TITLE
Add manual refresh worker and UI integration

### DIFF
--- a/backend/app/api/refresh.py
+++ b/backend/app/api/refresh.py
@@ -1,0 +1,54 @@
+"""Manual refresh API wiring the background worker into Flask."""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify, request
+
+bp = Blueprint("refresh_api", __name__, url_prefix="/api/refresh")
+
+
+def _get_worker():
+    return current_app.config.get("REFRESH_WORKER")
+
+
+@bp.post("")
+def trigger_refresh():
+    worker = _get_worker()
+    if worker is None:
+        return jsonify({"error": "refresh_unavailable"}), 503
+
+    payload = request.get_json(silent=True) or {}
+    query = (payload.get("query") or "").strip()
+    if not query:
+        return jsonify({"error": "missing_query"}), 400
+
+    use_llm_raw = payload.get("use_llm")
+    use_llm = bool(use_llm_raw) if use_llm_raw is not None else False
+    model = payload.get("model")
+    if isinstance(model, str):
+        model = model.strip() or None
+    else:
+        model = None
+
+    try:
+        job_id, status, created = worker.enqueue(query, use_llm=use_llm, model=model)
+    except ValueError as exc:
+        return jsonify({"error": "invalid_query", "detail": str(exc)}), 400
+
+    response = {"job_id": job_id, "status": status, "created": created}
+    if not created:
+        response["deduplicated"] = True
+    return jsonify(response), 202 if created else 200
+
+
+@bp.get("/status")
+def refresh_status():
+    worker = _get_worker()
+    if worker is None:
+        return jsonify({"error": "refresh_unavailable"}), 503
+
+    job_id = request.args.get("job_id")
+    query = request.args.get("query")
+    snapshot = worker.status(job_id=job_id, query=query)
+    return jsonify(snapshot)
+

--- a/server/refresh_worker.py
+++ b/server/refresh_worker.py
@@ -1,0 +1,283 @@
+"""Background worker dedicated to manual refresh requests."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+import uuid
+from collections import deque
+from typing import Deque, Dict, Optional
+
+from backend.app.config import AppConfig
+from backend.app.jobs.focused_crawl import run_focused_crawl
+
+
+class RefreshWorker:
+    """Track and execute manual refresh jobs serially."""
+
+    def __init__(self, config: AppConfig, *, max_history: int = 20) -> None:
+        self.config = config
+        self.max_history = max_history
+        self._queue: "queue.Queue[str]" = queue.Queue()
+        self._jobs: Dict[str, dict] = {}
+        self._query_to_job: Dict[str, str] = {}
+        self._history: Deque[str] = deque(maxlen=max_history)
+        self._lock = threading.RLock()
+        self._worker = threading.Thread(target=self._worker_loop, name="refresh-worker", daemon=True)
+        self._worker.start()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def enqueue(self, query: str, *, use_llm: bool = False, model: Optional[str] = None) -> tuple[str, dict, bool]:
+        """Queue a refresh for *query*; return (job_id, status, created)."""
+
+        normalized = self._normalize_query(query)
+        if not normalized:
+            raise ValueError("Query must be a non-empty string")
+
+        with self._lock:
+            existing_id = self._query_to_job.get(normalized)
+            if existing_id:
+                existing = self._jobs.get(existing_id)
+                if existing and existing.get("state") in {"queued", "running"}:
+                    return existing_id, self._snapshot(existing), False
+
+            job_id = uuid.uuid4().hex
+            now = time.time()
+            record = {
+                "id": job_id,
+                "query": query,
+                "normalized_query": normalized,
+                "state": "queued",
+                "stage": "queued",
+                "message": "Queued for refresh",
+                "progress": 0,
+                "use_llm": bool(use_llm),
+                "model": model,
+                "created_at": now,
+                "started_at": None,
+                "updated_at": now,
+                "completed_at": None,
+                "stats": {
+                    "seed_count": 0,
+                    "pages_fetched": 0,
+                    "normalized_docs": 0,
+                    "docs_indexed": 0,
+                    "skipped": 0,
+                    "deduped": 0,
+                },
+                "result": None,
+                "error": None,
+            }
+            self._jobs[job_id] = record
+            self._query_to_job[normalized] = job_id
+            self._queue.put(job_id)
+            return job_id, self._snapshot(record), True
+
+    def status(self, *, job_id: Optional[str] = None, query: Optional[str] = None) -> dict:
+        """Return a structured snapshot for a job or query."""
+
+        with self._lock:
+            if job_id and job_id in self._jobs:
+                return {"job": self._snapshot(self._jobs[job_id])}
+
+            if query:
+                normalized = self._normalize_query(query)
+                active_id = self._query_to_job.get(normalized)
+                if active_id and active_id in self._jobs:
+                    return {"job": self._snapshot(self._jobs[active_id])}
+
+                for history_id in reversed(self._history):
+                    job = self._jobs.get(history_id)
+                    if job and job.get("normalized_query") == normalized:
+                        return {"job": self._snapshot(job)}
+                return {"job": None}
+
+            active_jobs = [self._snapshot(self._jobs[jid]) for jid in self._query_to_job.values() if self._jobs.get(jid)]
+            recent_jobs = [self._snapshot(self._jobs[jid]) for jid in list(self._history)[-self.max_history :]]
+            return {"active": active_jobs, "recent": recent_jobs}
+
+    # ------------------------------------------------------------------
+    # Worker internals
+    # ------------------------------------------------------------------
+    def _worker_loop(self) -> None:
+        while True:
+            job_id = self._queue.get()
+            try:
+                self._run_job(job_id)
+            finally:
+                self._queue.task_done()
+
+    def _run_job(self, job_id: str) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            job["state"] = "running"
+            job["stage"] = "starting"
+            job["message"] = "Starting refresh…"
+            job["started_at"] = time.time()
+            job["updated_at"] = job["started_at"]
+
+        def _progress(stage: str, payload: dict) -> None:
+            self._handle_progress(job_id, stage, payload)
+
+        try:
+            result = run_focused_crawl(
+                job["query"],
+                self.config.focused_budget,
+                job.get("use_llm", False),
+                job.get("model"),
+                config=self.config,
+                progress_callback=_progress,
+            )
+        except Exception as exc:  # pragma: no cover - defensive path
+            self._mark_error(job_id, str(exc))
+            return
+
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            stats = job.get("stats", {})
+            stats.update(
+                {
+                    "pages_fetched": result.get("pages_fetched", stats.get("pages_fetched", 0)),
+                    "docs_indexed": result.get("docs_indexed", stats.get("docs_indexed", 0)),
+                    "skipped": result.get("skipped", stats.get("skipped", 0)),
+                    "deduped": result.get("deduped", stats.get("deduped", 0)),
+                    "normalized_docs": len(result.get("normalized_docs", [])),
+                }
+            )
+            job["stats"] = stats
+            job["state"] = "done"
+            job["stage"] = "complete"
+            job["message"] = "Refresh complete."
+            job["progress"] = 100
+            job["result"] = result
+            job["completed_at"] = time.time()
+            job["updated_at"] = job["completed_at"]
+            self._history.append(job_id)
+            normalized = job.get("normalized_query")
+            if normalized:
+                self._query_to_job.pop(normalized, None)
+
+    def _mark_error(self, job_id: str, error: str) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            job["state"] = "error"
+            job["stage"] = "error"
+            job["message"] = "Refresh failed."
+            job["error"] = error
+            job["progress"] = max(int(job.get("progress", 0)), 1)
+            job["completed_at"] = time.time()
+            job["updated_at"] = job["completed_at"]
+            self._history.append(job_id)
+            normalized = job.get("normalized_query")
+            if normalized:
+                self._query_to_job.pop(normalized, None)
+
+    def _handle_progress(self, job_id: str, stage: str, payload: dict) -> None:
+        message = self._stage_message(stage, payload)
+        increment = self._stage_progress(stage)
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job or job.get("state") == "error":
+                return
+            job["stage"] = stage
+            if message:
+                job["message"] = message
+            if increment is not None:
+                job["progress"] = max(int(job.get("progress", 0)), increment)
+            job["updated_at"] = time.time()
+            stats = job.get("stats", {})
+            if stage == "frontier_complete":
+                stats["seed_count"] = int(payload.get("seed_count", 0) or 0)
+            elif stage == "crawl_complete":
+                stats["pages_fetched"] = int(payload.get("pages_fetched", 0) or 0)
+            elif stage == "normalize_complete":
+                stats["normalized_docs"] = int(payload.get("docs", 0) or 0)
+            elif stage == "index_complete":
+                stats["docs_indexed"] = int(payload.get("docs_indexed", 0) or 0)
+                stats["skipped"] = int(payload.get("skipped", 0) or 0)
+                stats["deduped"] = int(payload.get("deduped", 0) or 0)
+            job["stats"] = stats
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _snapshot(self, job: dict) -> dict:
+        payload = {
+            "job_id": job.get("id"),
+            "query": job.get("query"),
+            "state": job.get("state"),
+            "stage": job.get("stage"),
+            "message": job.get("message"),
+            "progress": int(job.get("progress", 0)),
+            "use_llm": bool(job.get("use_llm")),
+            "model": job.get("model"),
+            "created_at": job.get("created_at"),
+            "started_at": job.get("started_at"),
+            "updated_at": job.get("updated_at"),
+            "completed_at": job.get("completed_at"),
+            "stats": dict(job.get("stats", {})),
+        }
+        if job.get("error"):
+            payload["error"] = job.get("error")
+        if job.get("result") is not None:
+            payload["result"] = job.get("result")
+        return payload
+
+    @staticmethod
+    def _normalize_query(query: str) -> str:
+        return " ".join((query or "").strip().split()).lower()
+
+    @staticmethod
+    def _stage_progress(stage: str) -> Optional[int]:
+        mapping = {
+            "starting": 5,
+            "frontier_start": 10,
+            "frontier_complete": 20,
+            "crawl_start": 30,
+            "crawl_complete": 55,
+            "normalize_start": 65,
+            "normalize_complete": 75,
+            "index_start": 85,
+            "index_complete": 95,
+            "index_skipped": 95,
+            "frontier_empty": 90,
+        }
+        return mapping.get(stage)
+
+    @staticmethod
+    def _stage_message(stage: str, payload: dict) -> Optional[str]:
+        if stage == "frontier_start":
+            return "Collecting crawl seeds…"
+        if stage == "frontier_complete":
+            count = int(payload.get("seed_count", 0) or 0)
+            return f"Planned {count} seed URL{'s' if count != 1 else ''}."
+        if stage == "crawl_start":
+            return "Crawling priority URLs…"
+        if stage == "crawl_complete":
+            pages = int(payload.get("pages_fetched", 0) or 0)
+            return f"Fetched {pages} page{'s' if pages != 1 else ''}."
+        if stage == "normalize_start":
+            return "Normalizing new documents…"
+        if stage == "normalize_complete":
+            docs = int(payload.get("docs", 0) or 0)
+            return f"Normalized {docs} document{'s' if docs != 1 else ''}."
+        if stage == "index_start":
+            return "Updating search index…"
+        if stage == "index_complete":
+            docs = int(payload.get("docs_indexed", 0) or 0)
+            return f"Indexed {docs} document{'s' if docs != 1 else ''}."
+        if stage == "index_skipped":
+            return "No new documents were indexed."
+        if stage == "frontier_empty":
+            return "No candidate URLs available for this query."
+        return None
+

--- a/static/style.css
+++ b/static/style.css
@@ -97,6 +97,59 @@ button {
   min-height: 1.5rem;
 }
 
+.refresh-panel {
+  background: rgba(20, 184, 166, 0.08);
+  border: 1px solid rgba(20, 184, 166, 0.2);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.refresh-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.refresh-controls button {
+  padding: 0.6rem 1.1rem;
+  font-size: 0.95rem;
+  background: #0f766e;
+}
+
+.refresh-controls button:hover,
+.refresh-controls button:focus {
+  background: #0d5f59;
+}
+
+.refresh-status-text {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.refresh-progress {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(20, 184, 166, 0.2);
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.refresh-progress div {
+  height: 100%;
+  width: 0%;
+  background: #0f766e;
+  transition: width 0.3s ease;
+}
+
+.refresh-help {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 118, 110, 0.85);
+}
+
 .embedder-status {
   background: rgba(37, 99, 235, 0.05);
   border: 1px solid rgba(37, 99, 235, 0.15);
@@ -192,6 +245,19 @@ button {
 
   .embedder-progress {
     background: rgba(37, 99, 235, 0.25);
+  }
+
+  .refresh-panel {
+    background: rgba(15, 118, 110, 0.18);
+    border-color: rgba(45, 212, 191, 0.35);
+  }
+
+  .refresh-progress {
+    background: rgba(45, 212, 191, 0.25);
+  }
+
+  .refresh-help {
+    color: rgba(94, 234, 212, 0.8);
   }
 
   .fallback-group select {

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,32 @@
             </p>
           </section>
           <section id="status" aria-live="polite" aria-busy="false"></section>
+          <section
+            id="manual-refresh"
+            class="refresh-panel"
+            aria-live="polite"
+            aria-busy="false"
+            hidden
+          >
+            <div class="refresh-controls">
+              <button type="button" id="refresh-button" disabled>Refresh now</button>
+              <p id="refresh-status-text" class="refresh-status-text">Trigger a focused crawl for this query.</p>
+            </div>
+            <div
+              id="refresh-progress"
+              class="refresh-progress"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="0"
+              hidden
+            >
+              <div id="refresh-progress-bar"></div>
+            </div>
+            <p class="refresh-help">
+              Run a one-off focused crawl without waiting for smart search thresholds.
+            </p>
+          </section>
           <section id="focused-status" class="focused-status" aria-live="polite" aria-busy="false" hidden>
             <h2>Focused crawl activity</h2>
             <p id="focused-message">Searching deeper…</p>
@@ -197,6 +223,11 @@ ollama pull llama3.1:8b-instruct</code></pre>
   const embedderFallbackApply = document.getElementById("embedder-fallback-apply");
   const embedderStartBtn = document.getElementById("embedder-start");
   const embedderHelpText = document.getElementById("embedder-help-text");
+  const refreshSection = document.getElementById("manual-refresh");
+  const refreshButton = document.getElementById("refresh-button");
+  const refreshStatusText = document.getElementById("refresh-status-text");
+  const refreshProgress = document.getElementById("refresh-progress");
+  const refreshProgressBar = document.getElementById("refresh-progress-bar");
   const chatTabs = document.querySelectorAll(".assist-tab");
   const chatPanel = document.getElementById("chat-panel");
   const researchPanel = document.getElementById("research-panel");
@@ -235,6 +266,12 @@ ollama pull llama3.1:8b-instruct</code></pre>
     chatMessages: [],
     researchJobId: null,
     researchPollTimer: null,
+    refresh: {
+      jobId: null,
+      pollTimer: null,
+      lastQuery: queryInput.value.trim(),
+      lastStatus: null,
+    },
     embedder: {
       status: null,
       pollTimer: null,
@@ -533,6 +570,246 @@ ollama pull llama3.1:8b-instruct</code></pre>
     } else if (status && status.state === "unknown" && status.auto_install !== false) {
       await refreshEmbedderStatus({ triggerInstall: true });
     }
+  }
+
+  function renderRefreshIdle(message = "Trigger a focused crawl for this query.") {
+    if (!refreshSection || !refreshStatusText) {
+      return;
+    }
+    refreshSection.hidden = false;
+    refreshSection.setAttribute("aria-busy", "false");
+    refreshStatusText.textContent = message;
+    if (refreshProgress) {
+      refreshProgress.hidden = true;
+      refreshProgress.setAttribute("aria-valuenow", "0");
+    }
+    if (refreshProgressBar) {
+      refreshProgressBar.style.width = "0%";
+    }
+  }
+
+  function stopManualRefreshPolling({ reset = false } = {}) {
+    if (state.refresh.pollTimer) {
+      clearInterval(state.refresh.pollTimer);
+      state.refresh.pollTimer = null;
+    }
+    if (reset) {
+      state.refresh.jobId = null;
+      state.refresh.lastStatus = null;
+    }
+  }
+
+  function updateRefreshAvailability() {
+    if (!refreshButton) {
+      return;
+    }
+    const rawQuery = queryInput.value.trim();
+    const normalized = rawQuery.toLowerCase();
+    const activeNormalized = (state.refresh.lastQuery || "").toLowerCase();
+    const hasQuery = Boolean(rawQuery);
+    if (!hasQuery) {
+      if (!state.refresh.jobId) {
+        renderRefreshIdle("Enter a query to refresh your index.");
+      }
+      refreshButton.disabled = true;
+      return;
+    }
+    if (state.refresh.jobId && normalized !== activeNormalized) {
+      stopManualRefreshPolling({ reset: true });
+      renderRefreshIdle("Ready to refresh the new query.");
+    } else if (!state.refresh.jobId) {
+      renderRefreshIdle();
+    }
+    refreshButton.disabled = Boolean(state.refresh.jobId);
+  }
+
+  function handleRefreshStatus(status) {
+    if (!refreshSection || !refreshStatusText) {
+      return;
+    }
+    state.refresh.lastStatus = status || null;
+    if (!status) {
+      renderRefreshIdle("No refresh activity yet.");
+      refreshButton.disabled = queryInput.value.trim() === "";
+      return;
+    }
+
+    const stateName = status.state || "unknown";
+    const stats = status.stats || {};
+    let message = status.message || `Refresh ${stateName}`;
+    if (stateName === "done") {
+      const docs = Number(stats.docs_indexed || 0);
+      const pages = Number(stats.pages_fetched || 0);
+      message = `Refresh complete. Indexed ${docs} document${docs === 1 ? "" : "s"} from ${pages} page${pages === 1 ? "" : "s"}.`;
+    } else if (stateName === "error" && status.error) {
+      message = `Refresh failed: ${status.error}`;
+    }
+
+    refreshSection.hidden = false;
+    const busy = stateName === "running" || stateName === "queued";
+    refreshSection.setAttribute("aria-busy", busy ? "true" : "false");
+    refreshStatusText.textContent = message;
+
+    const progressValue = Number(status.progress || 0);
+    if (refreshProgress) {
+      if (busy || progressValue > 0) {
+        refreshProgress.hidden = false;
+        refreshProgress.setAttribute("aria-valuenow", String(progressValue));
+      } else {
+        refreshProgress.hidden = true;
+        refreshProgress.setAttribute("aria-valuenow", "0");
+      }
+    }
+    if (refreshProgressBar) {
+      const width = Math.min(Math.max(progressValue, 0), 100);
+      refreshProgressBar.style.width = `${width}%`;
+    }
+
+    if (status.job_id) {
+      state.refresh.jobId = status.job_id;
+    }
+    if (status.query) {
+      state.refresh.lastQuery = status.query;
+    }
+
+    if (stateName === "done" || stateName === "error") {
+      stopManualRefreshPolling();
+      state.refresh.jobId = null;
+      if (refreshProgress) {
+        refreshProgress.hidden = true;
+        refreshProgress.setAttribute("aria-valuenow", "0");
+      }
+      if (refreshProgressBar) {
+        refreshProgressBar.style.width = "0%";
+      }
+      refreshButton.disabled = queryInput.value.trim() === "";
+    } else {
+      refreshButton.disabled = true;
+    }
+  }
+
+  async function pollRefreshStatus({ jobId, query } = {}) {
+    const activeJobId = jobId || state.refresh.jobId;
+    const lookupQuery = query || state.refresh.lastQuery;
+    if (!activeJobId && !lookupQuery) {
+      return;
+    }
+    const params = new URLSearchParams();
+    if (activeJobId) {
+      params.set("job_id", activeJobId);
+    }
+    if (lookupQuery) {
+      params.set("query", lookupQuery);
+    }
+    try {
+      const response = await fetch(`/api/refresh/status?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Refresh status failed: ${response.status}`);
+      }
+      const payload = await response.json();
+      handleRefreshStatus(payload.job || null);
+    } catch (error) {
+      console.error(error);
+      if (refreshStatusText) {
+        refreshStatusText.textContent = `Unable to read refresh status: ${error.message}`;
+      }
+      if (refreshSection) {
+        refreshSection.setAttribute("aria-busy", "false");
+      }
+      stopManualRefreshPolling();
+      state.refresh.jobId = null;
+      if (refreshButton) {
+        refreshButton.disabled = queryInput.value.trim() === "";
+      }
+    }
+  }
+
+  async function triggerManualRefresh() {
+    if (!refreshButton) {
+      return;
+    }
+    const query = queryInput.value.trim();
+    if (!query) {
+      renderRefreshIdle("Enter a query to refresh your index.");
+      return;
+    }
+    const payload = { query };
+    if (llmToggle.checked) {
+      payload.use_llm = true;
+      if (llmModelSelect.value) {
+        payload.model = llmModelSelect.value;
+      }
+    }
+
+    refreshButton.disabled = true;
+    if (refreshSection) {
+      refreshSection.hidden = false;
+      refreshSection.setAttribute("aria-busy", "true");
+    }
+    if (refreshProgress) {
+      refreshProgress.hidden = false;
+      refreshProgress.setAttribute("aria-valuenow", "5");
+    }
+    if (refreshProgressBar) {
+      refreshProgressBar.style.width = "5%";
+    }
+    if (refreshStatusText) {
+      refreshStatusText.textContent = "Queueing refresh…";
+    }
+
+    try {
+      const response = await fetch("/api/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || `HTTP ${response.status}`);
+      }
+      state.refresh.jobId = data.job_id || null;
+      state.refresh.lastQuery = query;
+      handleRefreshStatus(data.status || null);
+      if (state.refresh.pollTimer) {
+        clearInterval(state.refresh.pollTimer);
+      }
+      state.refresh.pollTimer = setInterval(() => {
+        pollRefreshStatus({ jobId: state.refresh.jobId });
+      }, 3000);
+      await pollRefreshStatus({ jobId: state.refresh.jobId });
+    } catch (error) {
+      console.error(error);
+      if (refreshStatusText) {
+        refreshStatusText.textContent = `Unable to trigger refresh: ${error.message}`;
+      }
+      if (refreshSection) {
+        refreshSection.setAttribute("aria-busy", "false");
+      }
+      if (refreshProgress) {
+        refreshProgress.hidden = true;
+        refreshProgress.setAttribute("aria-valuenow", "0");
+      }
+      if (refreshProgressBar) {
+        refreshProgressBar.style.width = "0%";
+      }
+      stopManualRefreshPolling({ reset: true });
+      refreshButton.disabled = queryInput.value.trim() === "";
+    }
+  }
+
+  function initManualRefresh() {
+    if (!refreshSection || !refreshButton) {
+      return;
+    }
+    refreshSection.hidden = false;
+    renderRefreshIdle();
+    refreshButton.addEventListener("click", () => {
+      triggerManualRefresh();
+    });
+    queryInput.addEventListener("input", () => {
+      updateRefreshAvailability();
+    });
+    updateRefreshAvailability();
   }
 
   function escapeHTML(text) {
@@ -841,6 +1118,10 @@ ollama pull llama3.1:8b-instruct</code></pre>
     const params = buildParams(auto);
     params.set("q", query);
     state.lastQuery = query;
+    state.refresh.lastQuery = query;
+    if (!state.refresh.jobId) {
+      updateRefreshAvailability();
+    }
 
     if (!skipEmbedCheck) {
       const ready = await ensureEmbedderReady({ auto });
@@ -1207,6 +1488,7 @@ ollama pull llama3.1:8b-instruct</code></pre>
     runSearch();
   });
 
+  initManualRefresh();
   initEmbedderStatus();
   setTab("chat");
   fetchLLMStatus();

--- a/tests/api/test_refresh_api.py
+++ b/tests/api/test_refresh_api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from backend.app import create_app
+from server import refresh_worker
+
+
+@pytest.fixture(autouse=True)
+def _patch_refresh_worker(monkeypatch: pytest.MonkeyPatch):
+    def fake_run(
+        query: str,
+        budget: int,
+        use_llm: bool,
+        model: str | None,
+        *,
+        config,
+        extra_seeds=None,
+        progress_callback=None,
+    ):
+        if progress_callback:
+            progress_callback("frontier_start", {"query": query})
+            progress_callback("frontier_complete", {"seed_count": 3})
+            progress_callback("crawl_start", {"seed_count": 3})
+        time.sleep(0.01)
+        if progress_callback:
+            progress_callback("crawl_complete", {"pages_fetched": 2})
+            progress_callback("normalize_complete", {"docs": 1})
+            progress_callback(
+                "index_complete",
+                {"docs_indexed": 1, "skipped": 0, "deduped": 0},
+            )
+        return {
+            "query": query,
+            "pages_fetched": 2,
+            "docs_indexed": 1,
+            "skipped": 0,
+            "deduped": 0,
+            "duration": 0.05,
+            "normalized_docs": [{}],
+            "raw_path": None,
+        }
+
+    monkeypatch.setattr(refresh_worker, "run_focused_crawl", fake_run)
+    yield
+
+
+def test_refresh_flow_and_status_polling():
+    app = create_app()
+    client = app.test_client()
+
+    response = client.post("/api/refresh", json={"query": "manual refresh"})
+    assert response.status_code == 202
+    payload = response.get_json()
+    assert payload["created"] is True
+    job_id = payload["job_id"]
+    assert isinstance(job_id, str)
+
+    deadline = time.time() + 2
+    final = None
+    while time.time() < deadline:
+        resp = client.get("/api/refresh/status", query_string={"job_id": job_id})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        final = data.get("job")
+        if final and final.get("state") == "done":
+            break
+        time.sleep(0.05)
+    assert final is not None
+    assert final["state"] == "done"
+    assert final["stats"]["docs_indexed"] == 1
+    assert final["stats"]["pages_fetched"] == 2
+
+
+def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
+    gate = threading.Event()
+    release = threading.Event()
+
+    def slow_run(
+        query: str,
+        budget: int,
+        use_llm: bool,
+        model: str | None,
+        *,
+        config,
+        extra_seeds=None,
+        progress_callback=None,
+    ):
+        if progress_callback:
+            progress_callback("frontier_start", {"query": query})
+        gate.set()
+        release.wait(timeout=2)
+        if progress_callback:
+            progress_callback("index_complete", {"docs_indexed": 0, "skipped": 0, "deduped": 0})
+        return {
+            "query": query,
+            "pages_fetched": 0,
+            "docs_indexed": 0,
+            "skipped": 0,
+            "deduped": 0,
+            "duration": 0.01,
+            "normalized_docs": [],
+            "raw_path": None,
+        }
+
+    monkeypatch.setattr(refresh_worker, "run_focused_crawl", slow_run)
+
+    app = create_app()
+    client = app.test_client()
+
+    first = client.post("/api/refresh", json={"query": "dedupe me"})
+    assert first.status_code == 202
+    first_payload = first.get_json()
+    job_id = first_payload["job_id"]
+    gate.wait(timeout=1)
+
+    second = client.post("/api/refresh", json={"query": "dedupe me"})
+    assert second.status_code == 200
+    second_payload = second.get_json()
+    assert second_payload["job_id"] == job_id
+    assert second_payload["created"] is False
+    assert second_payload["deduplicated"] is True
+
+    release.set()
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        resp = client.get("/api/refresh/status", query_string={"job_id": job_id})
+        assert resp.status_code == 200
+        job = resp.get_json()["job"]
+        if job and job.get("state") == "done":
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail("refresh job did not complete in time")


### PR DESCRIPTION
## Summary
- add a refresh worker to track focused crawl jobs with per-query dedupe and progress updates
- expose /api/refresh endpoints and wire the worker into the Flask app configuration
- surface a "Refresh now" control with progress UI, documentation, and integration tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0babb62388321a76133a9694b2025