### PR TITLE
Add value overrides to crawler frontier

### DIFF
--- a/tests/test_crawler_frontier.py
+++ b/tests/test_crawler_frontier.py
@@ -1,0 +1,44 @@
+from urllib.parse import urlparse
+
+import pytest
+
+from crawler.frontier import build_frontier
+
+
+def test_crawler_frontier_applies_value_overrides_before_dedupe():
+    candidates = build_frontier(
+        "docs",
+        extra_urls=["https://preferred.com/docs/"],
+        seed_domains=["preferred.com"],
+        budget=5,
+        value_overrides={"preferred.com": 4.0},
+    )
+
+    assert candidates, "expected crawler frontier candidates"
+
+    target = next(
+        candidate
+        for candidate in candidates
+        if urlparse(candidate.url).netloc == "preferred.com"
+        and candidate.url.startswith("https://preferred.com/docs")
+    )
+
+    assert target.weight == pytest.approx(4.0)
+
+
+def test_crawler_frontier_legacy_arguments_still_supported():
+    candidates = build_frontier(
+        "docs",
+        extra_urls=["preferred.com"],
+        budget=3,
+    )
+
+    assert candidates, "expected crawler frontier candidates"
+
+    domain_candidate = next(
+        candidate
+        for candidate in candidates
+        if urlparse(candidate.url).netloc == "preferred.com"
+    )
+
+    assert domain_candidate.weight == pytest.approx(1.5)


### PR DESCRIPTION
## Summary
- allow the crawler frontier to accept optional value overrides when weighting candidate URLs
- normalize override domains and merge their weights prior to deduplication so higher value candidates surface
- add unit tests covering crawler frontier overrides and legacy inputs

## Testing
- pytest tests/test_crawler_frontier.py tests/test_frontier.py
- pytest tests/api/test_refresh_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c15c35e88321a1541ae360401aed