### PR TITLE
Add seed registry loader and default definitions

### DIFF
--- a/seeds/registry.yaml
+++ b/seeds/registry.yaml
@@ -1,0 +1,41 @@
+sources:
+  - id: developer_docs
+    kind: curated
+    strategy: sitemap
+    entrypoints:
+      - https://developer.mozilla.org/
+      - https://docs.python.org/3/
+      - https://developer.apple.com/documentation/
+    trust: high
+  - id: open_source_hubs
+    kind: aggregator
+    strategy: feed
+    entrypoints:
+      - https://github.com/trending
+      - https://gitlab.com/explore
+      - https://bitbucket.org/product/discover
+    trust: medium
+  - id: technical_news
+    kind: editorial
+    strategy: headlines
+    entrypoints:
+      - https://news.ycombinator.com/
+      - https://www.theverge.com/tech
+      - https://www.techmeme.com/
+    trust: medium
+  - id: community_qna
+    kind: forum
+    strategy: crawl
+    entrypoints:
+      - https://stackoverflow.com/questions
+      - https://superuser.com/questions
+      - https://serverfault.com/questions
+    trust: medium
+  - id: government_open_data
+    kind: public_sector
+    strategy: catalog
+    entrypoints:
+      - https://data.gov/
+      - https://data.europa.eu/en
+      - https://www.data.gov.uk/
+    trust: high

--- a/server/seeds_loader.py
+++ b/server/seeds_loader.py
@@ -1,0 +1,164 @@
+"""Utilities for loading curated seed source registry definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, MutableMapping, Sequence
+from urllib.parse import urlparse
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_REGISTRY_PATH = ROOT_DIR / "seeds" / "registry.yaml"
+
+
+@dataclass(frozen=True)
+class SeedRegistryEntry:
+    """Normalized configuration for a seed discovery source."""
+
+    id: str
+    kind: str
+    strategy: str
+    entrypoints: tuple[str, ...]
+    trust: float | str
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dictionary representation of the entry."""
+
+        payload: dict[str, Any] = {
+            "id": self.id,
+            "kind": self.kind,
+            "strategy": self.strategy,
+            "entrypoints": list(self.entrypoints),
+            "trust": self.trust,
+        }
+        payload.update(self.extras)
+        return payload
+
+
+def _ensure_mapping(node: Any) -> Mapping[str, Any]:
+    if not isinstance(node, MutableMapping):
+        raise TypeError(f"expected mapping entries, got {type(node)!r}")
+    return node
+
+
+def _normalize_id(value: Any) -> str:
+    if value is None:
+        raise ValueError("registry entry is missing required 'id'")
+    text = str(value).strip()
+    if not text:
+        raise ValueError("registry entry 'id' cannot be empty")
+    return text
+
+
+def _normalize_simple_field(value: Any, name: str) -> str:
+    if value is None:
+        raise ValueError(f"registry entry is missing required '{name}'")
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"registry entry '{name}' cannot be empty")
+    return text.lower()
+
+
+def _normalize_entrypoints(value: Any) -> tuple[str, ...]:
+    if value is None:
+        raise ValueError("registry entry requires at least one entrypoint")
+
+    if isinstance(value, (str, bytes)):
+        candidates: Iterable[Any] = [value]
+    elif isinstance(value, Sequence):
+        candidates = value
+    else:
+        raise TypeError("entrypoints must be a string or sequence of strings")
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            url_candidate = candidate.get("url")
+        else:
+            url_candidate = candidate
+        if url_candidate is None:
+            continue
+        url_text = str(url_candidate).strip()
+        if not url_text:
+            continue
+        parsed = urlparse(url_text)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f"invalid entrypoint URL '{url_text}'")
+        if url_text not in seen:
+            normalized.append(url_text)
+            seen.add(url_text)
+
+    if not normalized:
+        raise ValueError("registry entry must define at least one valid entrypoint")
+    return tuple(normalized)
+
+
+def _normalize_trust(value: Any) -> float | str:
+    if value is None:
+        return "medium"
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("registry entry 'trust' cannot be empty")
+        lowered = text.lower()
+        if lowered in {"low", "medium", "high"}:
+            return lowered
+        try:
+            return float(text)
+        except ValueError as exc:  # pragma: no cover - defensive fallback
+            raise ValueError(f"invalid trust value '{value}'") from exc
+    raise TypeError("trust must be a string or numeric value")
+
+
+def _normalize_entry(raw: Mapping[str, Any]) -> SeedRegistryEntry:
+    data = dict(raw)
+    entry_id = _normalize_id(data.pop("id", None))
+    kind = _normalize_simple_field(data.pop("kind", None), "kind")
+    strategy = _normalize_simple_field(data.pop("strategy", None), "strategy")
+    entrypoints = _normalize_entrypoints(data.pop("entrypoints", None))
+    trust = _normalize_trust(data.pop("trust", None))
+    extras = {key: value for key, value in data.items() if value is not None}
+    return SeedRegistryEntry(
+        id=entry_id,
+        kind=kind,
+        strategy=strategy,
+        entrypoints=entrypoints,
+        trust=trust,
+        extras=extras,
+    )
+
+
+def load_seed_registry(path: str | Path | None = None) -> List[SeedRegistryEntry]:
+    """Load and normalize registry entries from ``seeds/registry.yaml``."""
+
+    registry_path = Path(path) if path else DEFAULT_REGISTRY_PATH
+    if not registry_path.exists():
+        return []
+
+    with registry_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        raw_entries = payload
+    else:
+        mapping = _ensure_mapping(payload)
+        raw_entries = mapping.get("sources", [])
+
+    entries: List[SeedRegistryEntry] = []
+    seen_ids: set[str] = set()
+    for item in raw_entries:
+        entry = _normalize_entry(_ensure_mapping(item))
+        if entry.id in seen_ids:
+            raise ValueError(f"duplicate seed registry id '{entry.id}'")
+        entries.append(entry)
+        seen_ids.add(entry.id)
+    return entries
+
+
+__all__ = ["DEFAULT_REGISTRY_PATH", "SeedRegistryEntry", "load_seed_registry"]

--- a/tests/test_server_seeds_loader.py
+++ b/tests/test_server_seeds_loader.py
@@ -1,0 +1,113 @@
+import pytest
+
+from server.seeds_loader import load_seed_registry
+
+
+def test_load_seed_registry_normalizes(tmp_path):
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """
+        sources:
+          - id: Docs
+            kind: CURATED
+            strategy: Sitemap
+            entrypoints:
+              - https://example.com/docs
+              - { url: https://example.com/docs }
+              - https://example.com/docs?ref=dup
+            trust: High
+            notes: keep-me
+          - id: numeric_trust
+            kind: mirror
+            strategy: manual
+            entrypoints: https://example.net/api
+            trust: 0.75
+        """,
+        encoding="utf-8",
+    )
+
+    entries = load_seed_registry(registry)
+    assert len(entries) == 2
+
+    docs_entry = entries[0]
+    assert docs_entry.id == "Docs"
+    assert docs_entry.kind == "curated"
+    assert docs_entry.strategy == "sitemap"
+    assert docs_entry.entrypoints == (
+        "https://example.com/docs",
+        "https://example.com/docs?ref=dup",
+    )
+    assert docs_entry.trust == "high"
+    assert docs_entry.extras == {"notes": "keep-me"}
+
+    numeric_entry = entries[1]
+    assert numeric_entry.trust == pytest.approx(0.75)
+    assert numeric_entry.entrypoints == ("https://example.net/api",)
+
+
+def test_load_seed_registry_accepts_top_level_array(tmp_path):
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """
+        - id: array
+          kind: curated
+          strategy: crawl
+          entrypoints:
+            - https://example.org
+          trust: medium
+        """,
+        encoding="utf-8",
+    )
+
+    entries = load_seed_registry(registry)
+    assert len(entries) == 1
+    assert entries[0].id == "array"
+
+
+def test_load_seed_registry_detects_duplicates(tmp_path):
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """
+        sources:
+          - id: dup
+            kind: curated
+            strategy: crawl
+            entrypoints:
+              - https://example.com
+            trust: low
+          - id: dup
+            kind: curated
+            strategy: crawl
+            entrypoints:
+              - https://example.net
+            trust: low
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_seed_registry(registry)
+
+
+def test_load_seed_registry_missing_file_returns_empty(tmp_path):
+    registry = tmp_path / "missing.yaml"
+    assert load_seed_registry(registry) == []
+
+
+def test_load_seed_registry_rejects_relative_entrypoints(tmp_path):
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(
+        """
+        sources:
+          - id: bad
+            kind: curated
+            strategy: crawl
+            entrypoints:
+              - /relative/path
+            trust: low
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_seed_registry(registry)


### PR DESCRIPTION
## Summary
- add a default seed registry file with generic discovery sources
- implement `server.seeds_loader` to normalize registry entries
- cover the loader with unit tests for normalization and validation

## Testing
- pytest tests/test_server_seeds_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c65f998083218bb466e781c52a68