### PR TITLE
Refine search trigger with learned seeding

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -22,6 +22,7 @@ from .config import AppConfig
 from .jobs.focused_crawl import FocusedCrawlManager
 from .jobs.runner import JobRunner
 from .metrics import metrics
+from .search.learned_web import LearnedWebStore
 from .search.service import SearchService
 from server.refresh_worker import RefreshWorker
 
@@ -55,7 +56,8 @@ def create_app() -> Flask:
 
     runner = JobRunner(config.logs_dir)
     manager = FocusedCrawlManager(config, runner)
-    search_service = SearchService(config, manager)
+    learned_store = LearnedWebStore(config.learned_web_db)
+    search_service = SearchService(config, manager, learned_store=learned_store)
     refresh_worker = RefreshWorker(config)
 
     app.config.update(
@@ -64,6 +66,7 @@ def create_app() -> Flask:
         FOCUSED_MANAGER=manager,
         SEARCH_SERVICE=search_service,
         REFRESH_WORKER=refresh_worker,
+        LEARNED_WEB_STORE=learned_store,
     )
 
     app.register_blueprint(search_api.bp)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,12 +29,16 @@ class AppConfig:
     focused_budget: int
     smart_min_results: int
     smart_trigger_cooldown: int
+    smart_min_confidence: float
     search_default_limit: int
     search_max_limit: int
     max_query_length: int
     ollama_url: str
     crawl_use_playwright: str
     use_llm_rerank: bool
+    learned_web_db: Path
+    learned_seed_limit: int
+    learned_min_similarity: float
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -52,12 +56,16 @@ class AppConfig:
         focused_budget = max(1, int(os.getenv("FOCUSED_CRAWL_BUDGET", "10")))
         smart_min_results = max(0, int(os.getenv("SMART_MIN_RESULTS", "1")))
         smart_trigger_cooldown = max(0, int(os.getenv("SMART_TRIGGER_COOLDOWN", "900")))
+        smart_min_confidence = float(os.getenv("SMART_MIN_CONFIDENCE", "0.35"))
         search_default_limit = max(1, int(os.getenv("SEARCH_DEFAULT_LIMIT", "20")))
         search_max_limit = max(search_default_limit, int(os.getenv("SEARCH_MAX_LIMIT", "50")))
         max_query_length = max(32, int(os.getenv("SEARCH_MAX_QUERY_LENGTH", "256")))
         ollama_url = os.getenv("OLLAMA_URL", os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")).rstrip("/")
         crawl_use_playwright = os.getenv("CRAWL_USE_PLAYWRIGHT", "auto").lower()
         use_llm_rerank = os.getenv("USE_LLM_RERANK", "false").lower() in {"1", "true", "yes", "on"}
+        learned_web_db = Path(os.getenv("LEARNED_WEB_DB", data_dir / "learned_web" / "discoveries.sqlite3"))
+        learned_seed_limit = max(0, int(os.getenv("LEARNED_WEB_SEED_LIMIT", "10")))
+        learned_min_similarity = float(os.getenv("LEARNED_WEB_MIN_SIMILARITY", "0.25"))
 
         return cls(
             index_dir=index_dir,
@@ -71,12 +79,16 @@ class AppConfig:
             focused_budget=focused_budget,
             smart_min_results=smart_min_results,
             smart_trigger_cooldown=smart_trigger_cooldown,
+            smart_min_confidence=smart_min_confidence,
             search_default_limit=search_default_limit,
             search_max_limit=search_max_limit,
             max_query_length=max_query_length,
             ollama_url=ollama_url,
             crawl_use_playwright=crawl_use_playwright,
             use_llm_rerank=use_llm_rerank,
+            learned_web_db=learned_web_db,
+            learned_seed_limit=learned_seed_limit,
+            learned_min_similarity=learned_min_similarity,
         )
 
     def ensure_dirs(self) -> None:
@@ -89,6 +101,7 @@ class AppConfig:
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
         self.simhash_path.parent.mkdir(parents=True, exist_ok=True)
         self.last_index_time_path.parent.mkdir(parents=True, exist_ok=True)
+        self.learned_web_db.parent.mkdir(parents=True, exist_ok=True)
 
     def log_summary(self) -> None:
         """Log environment-derived flags for observability."""
@@ -98,12 +111,16 @@ class AppConfig:
             "focused_budget": self.focused_budget,
             "smart_min_results": self.smart_min_results,
             "smart_trigger_cooldown": self.smart_trigger_cooldown,
+            "smart_min_confidence": round(self.smart_min_confidence, 3),
             "search_default_limit": self.search_default_limit,
             "search_max_limit": self.search_max_limit,
             "max_query_length": self.max_query_length,
             "ollama_url": self.ollama_url,
             "crawl_use_playwright": self.crawl_use_playwright,
             "use_llm_rerank": self.use_llm_rerank,
+            "learned_web_db": str(self.learned_web_db),
+            "learned_seed_limit": self.learned_seed_limit,
+            "learned_min_similarity": round(self.learned_min_similarity, 3),
         }
         LOGGER.info("runtime configuration: %s", json.dumps(payload, sort_keys=True))
 

--- a/backend/app/search/learned_web.py
+++ b/backend/app/search/learned_web.py
@@ -1,0 +1,173 @@
+"""Helpers for querying the Learned Web discovery cache."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import re
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _safe_float(value: object) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _norm(vector: Sequence[float]) -> float:
+    return math.sqrt(sum(component * component for component in vector))
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    if not left or not right:
+        return 0.0
+    limit = min(len(left), len(right))
+    if limit == 0:
+        return 0.0
+    dot = 0.0
+    for idx in range(limit):
+        dot += left[idx] * right[idx]
+    if dot <= 0.0:
+        return 0.0
+    left_norm = _norm(left[:limit])
+    right_norm = _norm(right[:limit])
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token.lower() for token in _TOKEN_RE.findall(text or "") if token]
+
+
+def _hashed_embedding(tokens: Iterable[str], *, dimension: int) -> List[float]:
+    vector = [0.0] * dimension
+    for token in tokens:
+        bucket = hash(token) % dimension
+        vector[bucket] += 1.0
+    norm = _norm(vector)
+    if norm == 0.0:
+        return vector
+    return [component / norm for component in vector]
+
+
+def _parse_embedding(payload: object) -> List[float]:
+    if payload is None:
+        return []
+    if isinstance(payload, (bytes, bytearray)):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            # Treat raw float array payloads as zero vectors.
+            return []
+    if isinstance(payload, str):
+        payload = payload.strip()
+        if not payload:
+            return []
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return []
+    else:
+        data = payload
+    if isinstance(data, list):
+        return [_safe_float(component) for component in data]
+    return []
+
+
+@dataclass
+class LearnedWebStore:
+    """Lightweight interface for the Learned Web SQLite database."""
+
+    path: Path
+    dimension: int = 256
+
+    def __post_init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def embed(self, text: str) -> List[float]:
+        tokens = _tokenize(text)
+        if not tokens:
+            return [0.0] * self.dimension
+        return _hashed_embedding(tokens, dimension=self.dimension)
+
+    def similar_urls(
+        self,
+        query: str,
+        *,
+        limit: int,
+        min_similarity: float,
+    ) -> List[str]:
+        query = (query or "").strip()
+        if not query or limit <= 0:
+            return []
+        if not self.path.exists():
+            return []
+
+        try:
+            vector = self.embed(query)
+        except Exception:
+            return []
+
+        with self._lock:
+            try:
+                connection = sqlite3.connect(str(self.path))
+            except sqlite3.Error:
+                return []
+            try:
+                connection.row_factory = sqlite3.Row
+                cursor = connection.execute(
+                    """
+                    SELECT url, embedding
+                    FROM discoveries
+                    WHERE embedding IS NOT NULL
+                    ORDER BY updated_at DESC
+                    LIMIT 512
+                    """
+                )
+                candidates: list[tuple[float, str]] = []
+                for row in cursor:
+                    if isinstance(row, sqlite3.Row):
+                        mapping = dict(row)
+                        url = mapping.get("url")
+                        embedding = mapping.get("embedding")
+                    else:
+                        url = row[0]
+                        embedding = row[1]
+                    parsed = _parse_embedding(embedding)
+                    if not parsed:
+                        continue
+                    similarity = _cosine_similarity(vector, parsed)
+                    if similarity < min_similarity:
+                        continue
+                    if isinstance(url, str) and url.strip():
+                        candidates.append((similarity, url.strip()))
+            except sqlite3.Error:
+                return []
+            finally:
+                connection.close()
+
+        candidates.sort(key=lambda item: item[0], reverse=True)
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for similarity, url in candidates:
+            if url in seen:
+                continue
+            seen.add(url)
+            ordered.append(url)
+            if len(ordered) >= limit:
+                break
+        return ordered
+
+
+__all__ = ["LearnedWebStore"]
+

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -132,7 +132,7 @@ class SearchService:
             job_id=job_id,
             triggered=triggered,
             confidence=confidence,
-            trigger_reason=trigger_reason if triggered else None,
+            trigger_reason=trigger_reason if trigger_attempted else None,
             trigger_attempted=trigger_attempted,
             frontier_seeds=tuple(seeds),
         )

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Optional, Sequence
 
 from search import query as query_module
 from rank import blend_results, maybe_rerank
@@ -13,14 +14,32 @@ from ..config import AppConfig
 from ..indexer.incremental import ensure_index
 from ..jobs.focused_crawl import FocusedCrawlManager
 from ..metrics import metrics
+from .learned_web import LearnedWebStore
 
 LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class SearchRunResult:
+    results: list[dict]
+    job_id: Optional[str]
+    triggered: bool
+    confidence: float
+    trigger_reason: Optional[str]
+    trigger_attempted: bool
+    frontier_seeds: tuple[str, ...] = ()
+
+
 class SearchService:
-    def __init__(self, config: AppConfig, manager: FocusedCrawlManager) -> None:
+    def __init__(
+        self,
+        config: AppConfig,
+        manager: FocusedCrawlManager,
+        learned_store: Optional[LearnedWebStore] = None,
+    ) -> None:
         self.config = config
         self.manager = manager
+        self.learned_store = learned_store
         self._lock = threading.Lock()
         self._index = None
         self._index_dir = None
@@ -40,7 +59,7 @@ class SearchService:
         limit: int,
         use_llm: Optional[bool],
         model: Optional[str],
-    ) -> Tuple[list[dict], Optional[str]]:
+    ) -> SearchRunResult:
         start = time.perf_counter()
         ix = self._get_index()
         results = query_module.search(
@@ -62,16 +81,82 @@ class SearchService:
                 metrics.record_llm_usage_event()
             blended = reranked
 
+        confidence = self._estimate_confidence(blended)
         job_id: Optional[str] = None
         triggered = False
+        trigger_attempted = False
+        trigger_reason: Optional[str] = None
+        seeds: list[str] = []
         if q:
             effective_use_llm = llm_enabled
-            job_id = self.manager.schedule(q, effective_use_llm, model)
-            triggered = bool(job_id)
-            if triggered:
-                metrics.record_focused_enqueue()
+            hits = len(blended)
+            if hits == 0:
+                trigger_attempted = True
+                trigger_reason = "no_results"
+            elif confidence < max(0.0, float(self.config.smart_min_confidence)):
+                trigger_attempted = True
+                trigger_reason = "low_confidence"
+
+            if trigger_attempted:
+                LOGGER.info(
+                    "focused crawl trigger attempt for '%s' (hits=%d confidence=%.3f reason=%s)",
+                    q,
+                    hits,
+                    confidence,
+                    trigger_reason,
+                )
+                if self.learned_store:
+                    try:
+                        seeds = self.learned_store.similar_urls(
+                            q,
+                            limit=self.config.learned_seed_limit,
+                            min_similarity=self.config.learned_min_similarity,
+                        )
+                    except Exception:  # pragma: no cover - defensive logging only
+                        LOGGER.exception("learned web lookup failed", exc_info=True)
+                        seeds = []
+                job_id = self.manager.schedule(
+                    q,
+                    effective_use_llm,
+                    model,
+                    extra_seeds=seeds or None,
+                )
+                triggered = bool(job_id)
+                if triggered:
+                    metrics.record_focused_enqueue()
+                else:
+                    seeds = []
         metrics.record_query_event(len(blended), triggered, duration_ms)
-        return blended, job_id
+        return SearchRunResult(
+            results=blended,
+            job_id=job_id,
+            triggered=triggered,
+            confidence=confidence,
+            trigger_reason=trigger_reason if triggered else None,
+            trigger_attempted=trigger_attempted,
+            frontier_seeds=tuple(seeds),
+        )
 
     def last_index_time(self) -> int:
         return self.manager.last_index_time()
+
+    def _estimate_confidence(self, results: Sequence[dict]) -> float:
+        if not results:
+            return 0.0
+        scores: list[float] = []
+        for item in results[:5]:
+            base = item.get("blended_score", item.get("score", 0.0))
+            try:
+                score = float(base)
+            except (TypeError, ValueError):
+                continue
+            if score > 0:
+                scores.append(score)
+        if not scores:
+            return 0.0
+        top = max(scores)
+        total = sum(scores)
+        if total <= 0:
+            return 0.0
+        confidence = top / total
+        return max(0.0, min(1.0, confidence))

--- a/tests/test_learned_web_store.py
+++ b/tests/test_learned_web_store.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from backend.app.search.learned_web import LearnedWebStore
+
+
+def test_learned_web_returns_empty_when_db_missing(tmp_path):
+    store = LearnedWebStore(tmp_path / "missing.sqlite3")
+    results = store.similar_urls("python packaging", limit=5, min_similarity=0.2)
+    assert results == []
+
+
+def test_learned_web_similarity_and_limit(tmp_path):
+    db_path = tmp_path / "learned.sqlite3"
+    store = LearnedWebStore(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE discoveries (
+            id INTEGER PRIMARY KEY,
+            url TEXT NOT NULL,
+            embedding TEXT NOT NULL,
+            updated_at REAL DEFAULT (strftime('%s','now'))
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO discoveries (url, embedding, updated_at) VALUES (?, ?, ?)",
+        [
+            (
+                "https://example.com/pkg-guide",
+                json.dumps(store.embed("python packaging guide")),
+                200.0,
+            ),
+            (
+                "https://example.com/python-intro",
+                json.dumps(store.embed("introduction to python")),
+                150.0,
+            ),
+            (
+                "https://example.com/gardening",
+                json.dumps(store.embed("gardening tips")),
+                300.0,
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    results = store.similar_urls("python packaging", limit=2, min_similarity=0.1)
+    assert results[0] == "https://example.com/pkg-guide"
+    assert "https://example.com/gardening" not in results
+    assert len(results) == 2

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -2,68 +2,191 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from backend.app.search.service import SearchService
+from backend.app.search.service import SearchRunResult, SearchService
 
 
-def test_run_query_always_schedules_refresh(monkeypatch, tmp_path):
-    config = SimpleNamespace(
-        index_dir=tmp_path / "index",
-        search_max_limit=20,
-        max_query_length=256,
-        smart_min_results=1,
-        use_llm_rerank=True,
+def _config(tmp_path, **overrides):
+    base = {
+        "index_dir": tmp_path / "index",
+        "search_max_limit": 20,
+        "max_query_length": 256,
+        "smart_min_results": 1,
+        "smart_min_confidence": 0.4,
+        "use_llm_rerank": True,
+        "learned_seed_limit": 5,
+        "learned_min_similarity": 0.3,
+        "learned_web_db": tmp_path / "learned.sqlite3",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class StubManager:
+    def __init__(self, *, job_ids: list[str | None] | None = None) -> None:
+        self.calls: list[tuple[str, bool, str | None, tuple[str, ...]]] = []
+        self._job_ids = list(job_ids or ["job-1"])
+
+    def schedule(
+        self,
+        query: str,
+        use_llm: bool,
+        model: str | None,
+        *,
+        extra_seeds: list[str] | None = None,
+    ) -> str | None:
+        seeds = tuple(extra_seeds or ())
+        self.calls.append((query, use_llm, model, seeds))
+        if not self._job_ids:
+            return None
+        return self._job_ids.pop(0)
+
+    def last_index_time(self) -> int:  # pragma: no cover - not exercised
+        return 0
+
+
+class StubLearnedStore:
+    def __init__(self, results: list[str]) -> None:
+        self.calls: list[tuple[str, int, float]] = []
+        self._results = results
+
+    def similar_urls(self, query: str, *, limit: int, min_similarity: float) -> list[str]:
+        self.calls.append((query, limit, min_similarity))
+        return list(self._results)
+
+
+def _patch_search(monkeypatch, results):
+    monkeypatch.setattr(
+        "backend.app.search.service.query_module.search",
+        lambda ix, query, limit, max_limit, max_query_length: results,
     )
+    monkeypatch.setattr("backend.app.search.service.blend_results", lambda payload: payload)
+    monkeypatch.setattr(
+        "backend.app.search.service.maybe_rerank",
+        lambda query, payload, enabled, model: payload,
+    )
+    monkeypatch.setattr("backend.app.search.service.metrics.record_search_latency", lambda ms: None)
+    monkeypatch.setattr("backend.app.search.service.metrics.record_llm_usage_event", lambda count=1: None)
 
-    class StubManager:
-        def __init__(self) -> None:
-            self.calls: list[tuple[str, bool, str | None]] = []
 
-        def schedule(self, query: str, use_llm: bool, model: str | None):
-            self.calls.append((query, use_llm, model))
-            return f"job-{len(self.calls)}"
-
-        def last_index_time(self) -> int:  # pragma: no cover - not exercised
-            return 0
-
+def test_run_query_triggers_when_no_hits(monkeypatch, tmp_path):
+    config = _config(tmp_path)
     manager = StubManager()
     service = SearchService(config, manager)
     service._get_index = lambda: object()
 
-    monkeypatch.setattr(
-        "backend.app.search.service.query_module.search",
-        lambda ix, query, limit, max_limit, max_query_length: [
-            {
-                "url": "https://example.com",
-                "title": "Example",
-                "snippet": "",
-                "score": 1.0,
-                "lang": "en",
-            }
-        ],
-    )
-    monkeypatch.setattr("backend.app.search.service.blend_results", lambda results: results)
-    monkeypatch.setattr(
-        "backend.app.search.service.maybe_rerank",
-        lambda query, results, enabled, model: results,
-    )
+    _patch_search(monkeypatch, [])
 
-    query_events: list[tuple[int, bool]] = []
+    recorded: list[tuple[int, bool]] = []
     monkeypatch.setattr(
         "backend.app.search.service.metrics.record_query_event",
-        lambda results_count, triggered, latency_ms: query_events.append((results_count, triggered)),
+        lambda results_count, triggered, latency_ms: recorded.append((results_count, triggered)),
     )
     focused_calls: list[int] = []
     monkeypatch.setattr(
         "backend.app.search.service.metrics.record_focused_enqueue",
         lambda count=1: focused_calls.append(count),
     )
-    monkeypatch.setattr("backend.app.search.service.metrics.record_search_latency", lambda ms: None)
-    monkeypatch.setattr("backend.app.search.service.metrics.record_llm_usage_event", lambda count=1: None)
 
-    results, job_id = service.run_query("docs", limit=5, use_llm=None, model="llama2")
+    run = service.run_query("docs", limit=5, use_llm=None, model="llama2")
 
-    assert results
-    assert job_id == "job-1"
-    assert manager.calls == [("docs", True, "llama2")]
-    assert query_events and query_events[0][1] is True
+    assert isinstance(run, SearchRunResult)
+    assert run.triggered is True
+    assert run.trigger_reason == "no_results"
+    assert run.job_id == "job-1"
+    assert manager.calls == [("docs", True, "llama2", ())]
+    assert recorded and recorded[0] == (0, True)
+    assert focused_calls == [1]
+
+
+def test_run_query_skips_trigger_when_confident(monkeypatch, tmp_path):
+    config = _config(tmp_path)
+    manager = StubManager(job_ids=[])
+    service = SearchService(config, manager)
+    service._get_index = lambda: object()
+
+    _patch_search(
+        monkeypatch,
+        [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "snippet": "",
+                "score": 1.0,
+                "lang": "en",
+                "blended_score": 1.0,
+            },
+            {
+                "url": "https://example.com/b",
+                "title": "B",
+                "snippet": "",
+                "score": 0.5,
+                "lang": "en",
+                "blended_score": 0.5,
+            },
+        ],
+    )
+
+    recorded: list[tuple[int, bool]] = []
+    monkeypatch.setattr(
+        "backend.app.search.service.metrics.record_query_event",
+        lambda results_count, triggered, latency_ms: recorded.append((results_count, triggered)),
+    )
+
+    run = service.run_query("docs", limit=5, use_llm=None, model=None)
+
+    assert run.triggered is False
+    assert run.job_id is None
+    assert run.trigger_attempted is False
+    assert manager.calls == []
+    assert recorded and recorded[0] == (2, False)
+
+
+def test_run_query_uses_learned_web_seeds(monkeypatch, tmp_path):
+    config = _config(tmp_path, smart_min_confidence=0.8, learned_seed_limit=3)
+    manager = StubManager()
+    learned_store = StubLearnedStore(["https://seed.one", "https://seed.two"])
+    service = SearchService(config, manager, learned_store=learned_store)
+    service._get_index = lambda: object()
+
+    _patch_search(
+        monkeypatch,
+        [
+            {
+                "url": "https://example.com/a",
+                "title": "A",
+                "snippet": "",
+                "score": 1.0,
+                "lang": "en",
+                "blended_score": 1.0,
+            },
+            {
+                "url": "https://example.com/b",
+                "title": "B",
+                "snippet": "",
+                "score": 1.0,
+                "lang": "en",
+                "blended_score": 1.0,
+            },
+        ],
+    )
+
+    focused_calls: list[int] = []
+    monkeypatch.setattr(
+        "backend.app.search.service.metrics.record_query_event",
+        lambda results_count, triggered, latency_ms: None,
+    )
+    monkeypatch.setattr(
+        "backend.app.search.service.metrics.record_focused_enqueue",
+        lambda count=1: focused_calls.append(count),
+    )
+
+    run = service.run_query("docs", limit=5, use_llm=None, model=None)
+
+    assert run.triggered is True
+    assert run.trigger_reason == "low_confidence"
+    assert run.frontier_seeds == ("https://seed.one", "https://seed.two")
+    assert manager.calls == [
+        ("docs", True, None, ("https://seed.one", "https://seed.two"))
+    ]
+    assert learned_store.calls == [("docs", 3, 0.3)]
     assert focused_calls == [1]


### PR DESCRIPTION
## Summary
- gate focused crawl scheduling behind zero-hit or low-confidence queries and surface the decision metadata through `/api/search`
- seed new crawls with similar discoveries from the Learned Web SQLite cache via a dedicated store wired into the app and configuration
- add regression coverage for the new trigger logic and learned web lookups

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0c66e9f648321bd1dc7c2c1b5b9fe