### PR TITLE
Add learned web SQLite persistence and integrate with crawl flows

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -24,6 +24,7 @@ from .jobs.runner import JobRunner
 from .metrics import metrics
 from .search.service import SearchService
 from server.refresh_worker import RefreshWorker
+from server.learned_web_db import get_db
 
 LOGGER = logging.getLogger(__name__)
 EMBEDDING_MODEL_PATTERNS = [
@@ -53,8 +54,9 @@ def create_app() -> Flask:
     config.ensure_dirs()
     config.log_summary()
 
+    db = get_db(config.learned_web_db_path)
     runner = JobRunner(config.logs_dir)
-    manager = FocusedCrawlManager(config, runner)
+    manager = FocusedCrawlManager(config, runner, db)
     search_service = SearchService(config, manager)
     refresh_worker = RefreshWorker(config)
 
@@ -64,6 +66,7 @@ def create_app() -> Flask:
         FOCUSED_MANAGER=manager,
         SEARCH_SERVICE=search_service,
         REFRESH_WORKER=refresh_worker,
+        LEARNED_WEB_DB=db,
     )
 
     app.register_blueprint(search_api.bp)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,7 @@ class AppConfig:
     simhash_path: Path
     last_index_time_path: Path
     logs_dir: Path
+    learned_web_db_path: Path
     focused_enabled: bool
     focused_budget: int
     smart_min_results: int
@@ -47,6 +48,7 @@ class AppConfig:
         simhash_path = Path(os.getenv("SIMHASH_PATH", data_dir / "simhash_index.json"))
         last_index_time_path = Path(os.getenv("LAST_INDEX_TIME_PATH", data_dir / ".last_index_time"))
         logs_dir = Path(os.getenv("LOGS_DIR", data_dir / "logs"))
+        learned_web_db_path = Path(os.getenv("LEARNED_WEB_DB_PATH", data_dir / "learned_web.sqlite3"))
 
         focused_enabled = os.getenv("FOCUSED_CRAWL_ENABLED", "0").lower() in {"1", "true", "yes", "on"}
         focused_budget = max(1, int(os.getenv("FOCUSED_CRAWL_BUDGET", "10")))
@@ -67,6 +69,7 @@ class AppConfig:
             simhash_path=simhash_path,
             last_index_time_path=last_index_time_path,
             logs_dir=logs_dir,
+            learned_web_db_path=learned_web_db_path,
             focused_enabled=focused_enabled,
             focused_budget=focused_budget,
             smart_min_results=smart_min_results,
@@ -89,6 +92,7 @@ class AppConfig:
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
         self.simhash_path.parent.mkdir(parents=True, exist_ok=True)
         self.last_index_time_path.parent.mkdir(parents=True, exist_ok=True)
+        self.learned_web_db_path.parent.mkdir(parents=True, exist_ok=True)
 
     def log_summary(self) -> None:
         """Log environment-derived flags for observability."""
@@ -104,6 +108,7 @@ class AppConfig:
             "ollama_url": self.ollama_url,
             "crawl_use_playwright": self.crawl_use_playwright,
             "use_llm_rerank": self.use_llm_rerank,
+            "learned_web_db_path": str(self.learned_web_db_path),
         }
         LOGGER.info("runtime configuration: %s", json.dumps(payload, sort_keys=True))
 

--- a/server/learned_web_db.py
+++ b/server/learned_web_db.py
@@ -1,0 +1,533 @@
+"""SQLite persistence for the learned web graph.
+
+This module tracks domains, pages, links, crawl executions and discovery
+events produced by the focused crawl pipeline.  It provides a thin helper
+class that hides SQLite plumbing while offering ergonomic helpers tailored to
+the crawler and search components.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+
+__all__ = [
+    "LearnedWebDB",
+    "get_db",
+]
+
+
+_DEFAULT_DB_ENV = "LEARNED_WEB_DB_PATH"
+
+
+def _normalize_host(url: str) -> Optional[str]:
+    candidate = (url or "").strip()
+    if not candidate:
+        return None
+    parsed = urlparse(candidate if "://" in candidate else f"https://{candidate}")
+    host = (parsed.netloc or parsed.path or "").strip().lower()
+    if not host:
+        return None
+    return host[4:] if host.startswith("www.") else host
+
+
+def _normalize_url(url: str) -> Optional[str]:
+    candidate = (url or "").strip()
+    if not candidate:
+        return None
+    if not candidate.startswith(("http://", "https://")):
+        candidate = f"https://{candidate.lstrip('/')}"
+    parsed = urlparse(candidate)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    path = parsed.path or "/"
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{parsed.scheme}://{parsed.netloc}{path}".rstrip("/")
+
+
+def _ts(value: Optional[float]) -> float:
+    return float(value if value is not None else time.time())
+
+
+@dataclass
+class LearnedWebDB:
+    """Small helper around a SQLite database storing learned web state."""
+
+    path: Path
+
+    def __post_init__(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(
+            str(self.path),
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            isolation_level=None,
+            check_same_thread=False,
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL;")
+        self._conn.execute("PRAGMA foreign_keys=ON;")
+        self._conn.execute("PRAGMA synchronous=NORMAL;")
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
+        self._initialize_schema()
+
+    # -- schema -----------------------------------------------------------------
+
+    def _initialize_schema(self) -> None:
+        ddl = """
+        CREATE TABLE IF NOT EXISTS domains (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            host TEXT NOT NULL UNIQUE,
+            first_seen REAL NOT NULL,
+            last_seen REAL NOT NULL,
+            learned_score REAL NOT NULL DEFAULT 0.0,
+            discovery_count INTEGER NOT NULL DEFAULT 0,
+            last_discovery_reason TEXT,
+            last_crawl_at REAL,
+            last_index_at REAL
+        );
+
+        CREATE TABLE IF NOT EXISTS crawls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            query TEXT NOT NULL,
+            started_at REAL NOT NULL,
+            completed_at REAL,
+            pages_fetched INTEGER NOT NULL DEFAULT 0,
+            docs_indexed INTEGER NOT NULL DEFAULT 0,
+            budget INTEGER,
+            seed_count INTEGER,
+            use_llm INTEGER NOT NULL DEFAULT 0,
+            model TEXT,
+            raw_path TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS pages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            url TEXT NOT NULL UNIQUE,
+            domain_id INTEGER NOT NULL,
+            title TEXT,
+            status INTEGER,
+            first_seen REAL NOT NULL,
+            last_seen REAL NOT NULL,
+            fetched_at REAL NOT NULL,
+            indexed_at REAL,
+            fingerprint_simhash INTEGER,
+            fingerprint_md5 TEXT,
+            crawl_id INTEGER,
+            FOREIGN KEY(domain_id) REFERENCES domains(id) ON DELETE CASCADE,
+            FOREIGN KEY(crawl_id) REFERENCES crawls(id) ON DELETE SET NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS links (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            from_page_id INTEGER NOT NULL,
+            to_url TEXT NOT NULL,
+            first_seen REAL NOT NULL,
+            last_seen REAL NOT NULL,
+            crawl_id INTEGER,
+            UNIQUE(from_page_id, to_url),
+            FOREIGN KEY(from_page_id) REFERENCES pages(id) ON DELETE CASCADE,
+            FOREIGN KEY(crawl_id) REFERENCES crawls(id) ON DELETE SET NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS discoveries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            query TEXT NOT NULL,
+            domain_id INTEGER NOT NULL,
+            url TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            source TEXT,
+            score REAL NOT NULL,
+            discovered_at REAL NOT NULL,
+            crawl_id INTEGER,
+            FOREIGN KEY(domain_id) REFERENCES domains(id) ON DELETE CASCADE,
+            FOREIGN KEY(crawl_id) REFERENCES crawls(id) ON DELETE SET NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_domains_last_seen ON domains(last_seen DESC);
+        CREATE INDEX IF NOT EXISTS idx_domains_learned_score ON domains(learned_score DESC);
+        CREATE INDEX IF NOT EXISTS idx_pages_domain_id ON pages(domain_id);
+        CREATE INDEX IF NOT EXISTS idx_links_to_url ON links(to_url);
+        CREATE INDEX IF NOT EXISTS idx_discoveries_query ON discoveries(query);
+        """
+        with self._lock:
+            self._conn.executescript(ddl)
+
+    # -- domain helpers ----------------------------------------------------------
+
+    def upsert_domain(
+        self,
+        host: str,
+        *,
+        seen_at: Optional[float] = None,
+        learned_score: Optional[float] = None,
+        increment_discovery: bool = False,
+        discovery_reason: Optional[str] = None,
+        last_crawl_at: Optional[float] = None,
+        last_index_at: Optional[float] = None,
+    ) -> Optional[int]:
+        normalized = _normalize_host(host)
+        if not normalized:
+            return None
+        ts = _ts(seen_at)
+        score = float(learned_score or 0.0)
+        discovery_count = 1 if increment_discovery else 0
+        reason = discovery_reason if increment_discovery else None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO domains (
+                    host,
+                    first_seen,
+                    last_seen,
+                    learned_score,
+                    discovery_count,
+                    last_discovery_reason,
+                    last_crawl_at,
+                    last_index_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(host) DO UPDATE SET
+                    last_seen = CASE
+                        WHEN excluded.last_seen > domains.last_seen THEN excluded.last_seen
+                        ELSE domains.last_seen
+                    END,
+                    learned_score = CASE
+                        WHEN excluded.learned_score > domains.learned_score THEN excluded.learned_score
+                        ELSE domains.learned_score
+                    END,
+                    discovery_count = domains.discovery_count + excluded.discovery_count,
+                    last_discovery_reason = CASE
+                        WHEN excluded.discovery_count > 0 THEN excluded.last_discovery_reason
+                        ELSE domains.last_discovery_reason
+                    END,
+                    last_crawl_at = CASE
+                        WHEN excluded.last_crawl_at IS NULL THEN domains.last_crawl_at
+                        WHEN domains.last_crawl_at IS NULL THEN excluded.last_crawl_at
+                        WHEN excluded.last_crawl_at > domains.last_crawl_at THEN excluded.last_crawl_at
+                        ELSE domains.last_crawl_at
+                    END,
+                    last_index_at = CASE
+                        WHEN excluded.last_index_at IS NULL THEN domains.last_index_at
+                        WHEN domains.last_index_at IS NULL THEN excluded.last_index_at
+                        WHEN excluded.last_index_at > domains.last_index_at THEN excluded.last_index_at
+                        ELSE domains.last_index_at
+                    END
+                ;
+                """,
+                (
+                    normalized,
+                    ts,
+                    ts,
+                    score,
+                    discovery_count,
+                    reason,
+                    last_crawl_at,
+                    last_index_at,
+                ),
+            )
+            row = self._conn.execute(
+                "SELECT id FROM domains WHERE host = ?",
+                (normalized,),
+            ).fetchone()
+        return int(row[0]) if row else None
+
+    def domain_value_map(self) -> dict[str, float]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT host, learned_score FROM domains WHERE learned_score > 0"
+            ).fetchall()
+        return {str(row[0]): float(row[1]) for row in rows}
+
+    def top_domains(self, limit: int = 50) -> list[str]:
+        limit = max(0, int(limit))
+        if limit == 0:
+            return []
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT host FROM domains
+                ORDER BY learned_score DESC, last_seen DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [str(row[0]) for row in rows]
+
+    # -- crawl lifecycle ---------------------------------------------------------
+
+    def start_crawl(
+        self,
+        query: str,
+        *,
+        started_at: Optional[float] = None,
+        budget: Optional[int] = None,
+        seed_count: Optional[int] = None,
+        use_llm: bool = False,
+        model: Optional[str] = None,
+    ) -> int:
+        ts = _ts(started_at)
+        with self._lock:
+            cursor = self._conn.execute(
+                """
+                INSERT INTO crawls (
+                    query,
+                    started_at,
+                    budget,
+                    seed_count,
+                    use_llm,
+                    model
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (query, ts, budget, seed_count, 1 if use_llm else 0, model),
+            )
+            return int(cursor.lastrowid)
+
+    def complete_crawl(
+        self,
+        crawl_id: int,
+        *,
+        completed_at: Optional[float] = None,
+        pages_fetched: int = 0,
+        docs_indexed: int = 0,
+        raw_path: Optional[str] = None,
+    ) -> None:
+        ts = _ts(completed_at)
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE crawls
+                SET completed_at = ?,
+                    pages_fetched = ?,
+                    docs_indexed = ?,
+                    raw_path = ?
+                WHERE id = ?
+                """,
+                (ts, int(pages_fetched), int(docs_indexed), raw_path, crawl_id),
+            )
+
+    # -- discoveries -------------------------------------------------------------
+
+    def record_discovery(
+        self,
+        query: str,
+        url: str,
+        *,
+        reason: str,
+        score: float,
+        source: Optional[str] = None,
+        discovered_at: Optional[float] = None,
+        crawl_id: Optional[int] = None,
+    ) -> Optional[int]:
+        normalized_url = _normalize_url(url)
+        if not normalized_url:
+            return None
+        host = _normalize_host(normalized_url)
+        if not host:
+            return None
+        ts = _ts(discovered_at)
+        domain_id = self.upsert_domain(
+            host,
+            seen_at=ts,
+            learned_score=score,
+            increment_discovery=True,
+            discovery_reason=reason,
+        )
+        if domain_id is None:
+            return None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO discoveries (
+                    query,
+                    domain_id,
+                    url,
+                    reason,
+                    source,
+                    score,
+                    discovered_at,
+                    crawl_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (query, domain_id, normalized_url, reason, source, float(score), ts, crawl_id),
+            )
+        return domain_id
+
+    # -- pages & links -----------------------------------------------------------
+
+    def record_page(
+        self,
+        crawl_id: Optional[int],
+        *,
+        url: str,
+        status: Optional[int],
+        title: Optional[str],
+        fetched_at: Optional[float],
+        fingerprint_simhash: Optional[int] = None,
+        fingerprint_md5: Optional[str] = None,
+    ) -> Optional[int]:
+        normalized_url = _normalize_url(url)
+        if not normalized_url:
+            return None
+        host = _normalize_host(normalized_url)
+        if not host:
+            return None
+        ts = _ts(fetched_at)
+        domain_id = self.upsert_domain(host, last_crawl_at=ts)
+        if domain_id is None:
+            return None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO pages (
+                    url,
+                    domain_id,
+                    title,
+                    status,
+                    first_seen,
+                    last_seen,
+                    fetched_at,
+                    indexed_at,
+                    fingerprint_simhash,
+                    fingerprint_md5,
+                    crawl_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+                ON CONFLICT(url) DO UPDATE SET
+                    domain_id = excluded.domain_id,
+                    title = excluded.title,
+                    status = excluded.status,
+                    last_seen = CASE
+                        WHEN excluded.last_seen > pages.last_seen THEN excluded.last_seen
+                        ELSE pages.last_seen
+                    END,
+                    fetched_at = excluded.fetched_at,
+                    fingerprint_simhash = excluded.fingerprint_simhash,
+                    fingerprint_md5 = excluded.fingerprint_md5,
+                    crawl_id = excluded.crawl_id
+                ;
+                """,
+                (
+                    normalized_url,
+                    domain_id,
+                    title,
+                    status,
+                    ts,
+                    ts,
+                    ts,
+                    fingerprint_simhash,
+                    fingerprint_md5,
+                    crawl_id,
+                ),
+            )
+            row = self._conn.execute(
+                "SELECT id FROM pages WHERE url = ?",
+                (normalized_url,),
+            ).fetchone()
+        return int(row[0]) if row else None
+
+    def record_links(
+        self,
+        from_page_id: int,
+        links: Iterable[str],
+        *,
+        discovered_at: Optional[float] = None,
+        crawl_id: Optional[int] = None,
+    ) -> None:
+        ts = _ts(discovered_at)
+        payload = []
+        for link in links:
+            normalized = _normalize_url(link)
+            if not normalized:
+                continue
+            payload.append((from_page_id, normalized, ts, ts, crawl_id))
+        if not payload:
+            return
+        with self._lock:
+            self._conn.executemany(
+                """
+                INSERT INTO links (
+                    from_page_id,
+                    to_url,
+                    first_seen,
+                    last_seen,
+                    crawl_id
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(from_page_id, to_url) DO UPDATE SET
+                    last_seen = CASE
+                        WHEN excluded.last_seen > links.last_seen THEN excluded.last_seen
+                        ELSE links.last_seen
+                    END,
+                    crawl_id = excluded.crawl_id
+                ;
+                """,
+                payload,
+            )
+
+    def mark_pages_indexed(
+        self,
+        urls: Iterable[str],
+        *,
+        indexed_at: Optional[float] = None,
+    ) -> None:
+        ts = _ts(indexed_at)
+        normalized_urls = []
+        for url in urls:
+            normalized = _normalize_url(url)
+            if normalized:
+                normalized_urls.append(normalized)
+        if not normalized_urls:
+            return
+        with self._lock:
+            for normalized in normalized_urls:
+                self._conn.execute(
+                    """
+                    UPDATE pages
+                    SET indexed_at = CASE
+                            WHEN indexed_at IS NULL OR ? > indexed_at THEN ?
+                            ELSE indexed_at
+                        END,
+                        last_seen = CASE
+                            WHEN ? > last_seen THEN ?
+                            ELSE last_seen
+                        END
+                    WHERE url = ?
+                    """,
+                    (ts, ts, ts, ts, normalized),
+                )
+                self._conn.execute(
+                    """
+                    UPDATE domains
+                    SET last_index_at = CASE
+                            WHEN last_index_at IS NULL OR ? > last_index_at THEN ?
+                            ELSE last_index_at
+                        END
+                    WHERE id = (
+                        SELECT domain_id FROM pages WHERE url = ?
+                    )
+                    """,
+                    (ts, ts, normalized),
+                )
+
+
+_DB_CACHE: dict[Path, LearnedWebDB] = {}
+_DB_CACHE_LOCK = threading.Lock()
+
+
+def _default_path() -> Path:
+    data_dir = Path(os.getenv("DATA_DIR", "data"))
+    return Path(os.getenv(_DEFAULT_DB_ENV, data_dir / "learned_web.sqlite3"))
+
+
+def get_db(path: Optional[Path] = None) -> LearnedWebDB:
+    resolved = Path(path) if path else _default_path()
+    with _DB_CACHE_LOCK:
+        db = _DB_CACHE.get(resolved)
+        if db is None:
+            db = LearnedWebDB(resolved)
+            _DB_CACHE[resolved] = db
+        return db

--- a/tests/test_learned_web_db.py
+++ b/tests/test_learned_web_db.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sqlite3
+
+from frontier.dedupe import ContentFingerprint
+
+from server.learned_web_db import LearnedWebDB
+
+
+def test_learned_web_db_persists_discovery_and_pages(tmp_path) -> None:
+    db_path = tmp_path / "learned.sqlite3"
+    db = LearnedWebDB(db_path)
+
+    assert db.domain_value_map() == {}
+
+    domain_id = db.record_discovery(
+        "test query",
+        "https://example.com/docs",
+        reason="frontier",
+        score=1.2,
+        source="seed",
+        discovered_at=123.0,
+    )
+    assert domain_id is not None
+
+    value_map = db.domain_value_map()
+    assert value_map["example.com"] >= 1.2
+
+    crawl_id = db.start_crawl(
+        "test query",
+        started_at=200.0,
+        budget=5,
+        seed_count=3,
+        use_llm=True,
+        model="mini",
+    )
+
+    fingerprint = ContentFingerprint(simhash=42, md5="abc123")
+    page_id = db.record_page(
+        crawl_id,
+        url="https://example.com/docs",
+        status=200,
+        title="Docs",
+        fetched_at=201.0,
+        fingerprint_simhash=fingerprint.simhash,
+        fingerprint_md5=fingerprint.md5,
+    )
+    assert page_id is not None
+
+    db.record_links(
+        page_id,
+        ["https://example.com/blog", "https://other.dev/guide"],
+        discovered_at=202.0,
+        crawl_id=crawl_id,
+    )
+
+    db.mark_pages_indexed(["https://example.com/docs"], indexed_at=203.0)
+    db.complete_crawl(crawl_id, completed_at=204.0, pages_fetched=1, docs_indexed=1, raw_path="/tmp/raw.json")
+
+    reopened = LearnedWebDB(db_path)
+    top = reopened.top_domains(5)
+    assert "example.com" in top
+
+    with sqlite3.connect(db_path) as conn:
+        discovery_count = conn.execute(
+            "SELECT discovery_count FROM domains WHERE host = ?",
+            ("example.com",),
+        ).fetchone()
+        assert discovery_count and discovery_count[0] >= 1
+
+        indexed_at = conn.execute(
+            "SELECT indexed_at FROM pages WHERE url = ?",
+            ("https://example.com/docs",),
+        ).fetchone()
+        assert indexed_at and indexed_at[0] >= 203.0
+
+        link_count = conn.execute("SELECT COUNT(*) FROM links").fetchone()
+        assert link_count and link_count[0] >= 2


### PR DESCRIPTION
## Summary
- add a SQLite-backed LearnedWebDB module that stores domains, pages, links, crawls, and discovery events
- wire the learned web database into configuration, focused crawl orchestration, and seed/frontier helpers so discoveries and crawl results are persisted and reused
- cover the new database helpers with unit tests and reuse learned scores when selecting top domains

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0c6652d3c832187bbd092792ffda5