### PR TITLE
Enhance manual refresh workflow with discovery metadata

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -56,7 +56,7 @@ def create_app() -> Flask:
     runner = JobRunner(config.logs_dir)
     manager = FocusedCrawlManager(config, runner)
     search_service = SearchService(config, manager)
-    refresh_worker = RefreshWorker(config)
+    refresh_worker = RefreshWorker(config, search_service=search_service)
 
     app.config.update(
         APP_CONFIG=config,

--- a/backend/app/api/refresh.py
+++ b/backend/app/api/refresh.py
@@ -11,6 +11,10 @@ def _get_worker():
     return current_app.config.get("REFRESH_WORKER")
 
 
+def _get_config():
+    return current_app.config.get("APP_CONFIG")
+
+
 @bp.post("")
 def trigger_refresh():
     worker = _get_worker()
@@ -22,6 +26,36 @@ def trigger_refresh():
     if not query:
         return jsonify({"error": "missing_query"}), 400
 
+    config = _get_config()
+
+    budget_value = payload.get("budget")
+    try:
+        budget = int(budget_value)
+    except (TypeError, ValueError):
+        budget = None
+    if budget is None or budget <= 0:
+        budget = getattr(config, "focused_budget", 10)
+
+    depth_value = payload.get("depth")
+    try:
+        depth = int(depth_value)
+    except (TypeError, ValueError):
+        depth = None
+    if depth is None or depth <= 0:
+        depth = getattr(config, "focused_depth", 2)
+
+    seeds_payload = payload.get("seeds")
+    seeds: list[str] = []
+    if isinstance(seeds_payload, (list, tuple)):
+        for item in seeds_payload:
+            if isinstance(item, str):
+                candidate = item.strip()
+                if candidate:
+                    seeds.append(candidate)
+
+    force_raw = payload.get("force")
+    force = bool(force_raw) if force_raw is not None else False
+
     use_llm_raw = payload.get("use_llm")
     use_llm = bool(use_llm_raw) if use_llm_raw is not None else False
     model = payload.get("model")
@@ -31,7 +65,15 @@ def trigger_refresh():
         model = None
 
     try:
-        job_id, status, created = worker.enqueue(query, use_llm=use_llm, model=model)
+        job_id, status, created = worker.enqueue(
+            query,
+            budget=budget,
+            depth=depth,
+            force=force,
+            seeds=seeds,
+            use_llm=use_llm,
+            model=model,
+        )
     except ValueError as exc:
         return jsonify({"error": "invalid_query", "detail": str(exc)}), 400
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ class AppConfig:
     logs_dir: Path
     focused_enabled: bool
     focused_budget: int
+    focused_depth: int
     smart_min_results: int
     smart_trigger_cooldown: int
     search_default_limit: int
@@ -35,6 +36,7 @@ class AppConfig:
     ollama_url: str
     crawl_use_playwright: str
     use_llm_rerank: bool
+    discovery_metadata_path: Path
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -50,6 +52,7 @@ class AppConfig:
 
         focused_enabled = os.getenv("FOCUSED_CRAWL_ENABLED", "0").lower() in {"1", "true", "yes", "on"}
         focused_budget = max(1, int(os.getenv("FOCUSED_CRAWL_BUDGET", "10")))
+        focused_depth = max(1, int(os.getenv("FOCUSED_CRAWL_DEPTH", "2")))
         smart_min_results = max(0, int(os.getenv("SMART_MIN_RESULTS", "1")))
         smart_trigger_cooldown = max(0, int(os.getenv("SMART_TRIGGER_COOLDOWN", "900")))
         search_default_limit = max(1, int(os.getenv("SEARCH_DEFAULT_LIMIT", "20")))
@@ -58,6 +61,13 @@ class AppConfig:
         ollama_url = os.getenv("OLLAMA_URL", os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")).rstrip("/")
         crawl_use_playwright = os.getenv("CRAWL_USE_PLAYWRIGHT", "auto").lower()
         use_llm_rerank = os.getenv("USE_LLM_RERANK", "false").lower() in {"1", "true", "yes", "on"}
+
+        discovery_metadata_path = Path(
+            os.getenv(
+                "DISCOVERY_METADATA_PATH",
+                crawl_root / "discovery_metadata.jsonl",
+            )
+        )
 
         return cls(
             index_dir=index_dir,
@@ -69,6 +79,7 @@ class AppConfig:
             logs_dir=logs_dir,
             focused_enabled=focused_enabled,
             focused_budget=focused_budget,
+            focused_depth=focused_depth,
             smart_min_results=smart_min_results,
             smart_trigger_cooldown=smart_trigger_cooldown,
             search_default_limit=search_default_limit,
@@ -77,6 +88,7 @@ class AppConfig:
             ollama_url=ollama_url,
             crawl_use_playwright=crawl_use_playwright,
             use_llm_rerank=use_llm_rerank,
+            discovery_metadata_path=discovery_metadata_path,
         )
 
     def ensure_dirs(self) -> None:
@@ -89,6 +101,7 @@ class AppConfig:
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
         self.simhash_path.parent.mkdir(parents=True, exist_ok=True)
         self.last_index_time_path.parent.mkdir(parents=True, exist_ok=True)
+        self.discovery_metadata_path.parent.mkdir(parents=True, exist_ok=True)
 
     def log_summary(self) -> None:
         """Log environment-derived flags for observability."""

--- a/backend/app/jobs/research.py
+++ b/backend/app/jobs/research.py
@@ -95,6 +95,9 @@ def run_research(query: str, model: Optional[str], budget: int, *, config: AppCo
         model=model,
         config=config,
         extra_seeds=extra_sources,
+        frontier_budget=budget,
+        frontier_depth=config.focused_depth,
+        discovery_metadata_path=config.discovery_metadata_path,
     )
 
     docs = stats.get("normalized_docs", [])

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -75,3 +75,10 @@ class SearchService:
 
     def last_index_time(self) -> int:
         return self.manager.last_index_time()
+
+    def refresh_index(self) -> None:
+        """Force the Whoosh index handle to reload from disk."""
+
+        with self._lock:
+            self._index = ensure_index(self.config.index_dir)
+            self._index_dir = self.config.index_dir

--- a/tests/api/test_refresh_api.py
+++ b/tests/api/test_refresh_api.py
@@ -19,6 +19,9 @@ def _patch_refresh_worker(monkeypatch: pytest.MonkeyPatch):
         *,
         config,
         extra_seeds=None,
+        frontier_budget=None,
+        frontier_depth=None,
+        discovery_metadata_path=None,
         progress_callback=None,
     ):
         if progress_callback:
@@ -39,9 +42,16 @@ def _patch_refresh_worker(monkeypatch: pytest.MonkeyPatch):
             "docs_indexed": 1,
             "skipped": 0,
             "deduped": 0,
+            "embedded": 1,
+            "new_domains": 1,
             "duration": 0.05,
             "normalized_docs": [{}],
             "raw_path": None,
+            "discovery": {
+                "query": query,
+                "seed_count": 3,
+                "new_domains_count": 1,
+            },
         }
 
     monkeypatch.setattr(refresh_worker, "run_focused_crawl", fake_run)
@@ -73,6 +83,10 @@ def test_refresh_flow_and_status_polling():
     assert final["state"] == "done"
     assert final["stats"]["docs_indexed"] == 1
     assert final["stats"]["pages_fetched"] == 2
+    assert final["stats"]["fetched"] == 2
+    assert final["stats"]["updated"] == 1
+    assert final["stats"]["embedded"] == 1
+    assert final["stats"]["new_domains"] == 1
 
 
 def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
@@ -87,6 +101,9 @@ def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
         *,
         config,
         extra_seeds=None,
+        frontier_budget=None,
+        frontier_depth=None,
+        discovery_metadata_path=None,
         progress_callback=None,
     ):
         if progress_callback:
@@ -101,9 +118,12 @@ def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
             "docs_indexed": 0,
             "skipped": 0,
             "deduped": 0,
+            "embedded": 0,
+            "new_domains": 0,
             "duration": 0.01,
             "normalized_docs": [],
             "raw_path": None,
+            "discovery": {"query": query, "seed_count": 0, "new_domains_count": 0},
         }
 
     monkeypatch.setattr(refresh_worker, "run_focused_crawl", slow_run)

--- a/tests/test_cold_start.py
+++ b/tests/test_cold_start.py
@@ -7,7 +7,19 @@ from backend.app.config import AppConfig
 from backend.app.indexer.incremental import incremental_index
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    frontier_budget=None,
+    frontier_depth=None,
+    discovery_metadata_path=None,
+    progress_callback=None,
+):
     config.ensure_dirs()
     doc = {
         "url": f"https://local-doc/{query.replace(' ', '-')}",
@@ -24,15 +36,23 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         config.last_index_time_path,
         [doc],
     )
+    discovery = {
+        "query": query,
+        "seed_count": 1,
+        "new_domains_count": 1,
+    }
     return {
         "query": query,
         "pages_fetched": 1,
         "docs_indexed": 1,
         "skipped": 0,
         "deduped": 0,
+        "embedded": 1,
+        "new_domains": 1,
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "discovery": discovery,
     }
 
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -24,7 +24,19 @@ def fake_ollama_request(url, model, system, prompt):
     return "# Research Report\n\n- Key point one[^1]\n- Key point two[^2]\n- Key point three[^3]\n\n[^1]: https://example.com/one\n[^2]: https://example.com/two\n[^3]: https://example.com/three"
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    frontier_budget=None,
+    frontier_depth=None,
+    discovery_metadata_path=None,
+    progress_callback=None,
+):
     config.ensure_dirs()
     doc = {
         "url": "https://example.com/one",
@@ -40,15 +52,23 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         config.last_index_time_path,
         [doc],
     )
+    discovery = {
+        "query": query,
+        "seed_count": 1,
+        "new_domains_count": 1,
+    }
     return {
         "query": query,
         "pages_fetched": 1,
         "docs_indexed": 1,
         "skipped": 0,
         "deduped": 0,
+        "embedded": 1,
+        "new_domains": 1,
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "discovery": discovery,
     }
 
 


### PR DESCRIPTION
## Summary
- allow `/api/refresh` to accept budgets, depth, seeds, and force options while defaulting to discovery runs
- persist discovery metadata, propagate frontier settings, and hot-reload the index when refresh jobs finish
- capture richer refresh statistics and update tests/configuration to cover the new behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0c66a294083219b93dc562f657889