### PR TITLE
Add discovery engine and frontier scheduling

### DIFF
--- a/backend/app/jobs/focused_crawl.py
+++ b/backend/app/jobs/focused_crawl.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence
-from urllib.parse import urlparse
 
-from crawler.frontier import Candidate, build_frontier
+from crawler.frontier import Candidate
 from crawler.run import FocusedCrawler
-from search.seeds import DEFAULT_SEEDS_PATH, get_top_domains
+from server.discover import DiscoveryEngine
 
 from ..config import AppConfig
 from ..indexer.incremental import incremental_index
@@ -107,36 +105,6 @@ def run_focused_crawl(
     return stats
 
 
-def _load_curated_values(path: Path) -> dict[str, float]:
-    values: dict[str, float] = {}
-    if not path.exists():
-        return values
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                text = line.strip()
-                if not text:
-                    continue
-                try:
-                    payload = json.loads(text)
-                except json.JSONDecodeError:
-                    continue
-                url = payload.get("url")
-                if not isinstance(url, str):
-                    continue
-                domain = urlparse(url).netloc.lower()
-                if domain.startswith("www."):
-                    domain = domain[4:]
-                try:
-                    score = float(payload.get("value_prior", 0.0))
-                except (TypeError, ValueError):
-                    score = 0.0
-                values[domain] = max(values.get(domain, 0.0), score)
-    except OSError:
-        return values
-    return values
-
-
 def _get_seed_candidates(
     query: str,
     budget: int,
@@ -149,33 +117,6 @@ def _get_seed_candidates(
     q = (query or "").strip()
     if not q:
         return []
-    try:
-        seed_domains = get_top_domains(limit=25)
-    except Exception:  # pragma: no cover - defensive
-        seed_domains = []
-    value_overrides: dict[str, float] = {}
-    data_root = Path(os.getenv("DATA_DIR", "data"))
-    value_overrides.update(_load_curated_values(data_root / "seeds" / "curated_seeds.jsonl"))
-    try:
-        with DEFAULT_SEEDS_PATH.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                text = line.strip()
-                if not text:
-                    continue
-                try:
-                    payload = json.loads(text)
-                except json.JSONDecodeError:
-                    continue
-                domain = (payload.get("domain") or "").strip().lower()
-                if not domain:
-                    continue
-                try:
-                    score = float(payload.get("score", 0.0))
-                except (TypeError, ValueError):
-                    score = 0.0
-                value_overrides[domain] = max(value_overrides.get(domain, 0.0), score)
-    except OSError:
-        pass
     llm_urls: List[str] = []
     if use_llm:
         try:
@@ -190,19 +131,22 @@ def _get_seed_candidates(
             merged_extra.append(source)
     merged_extra.extend(llm_urls)
 
-    candidates = build_frontier(
+    engine = DiscoveryEngine()
+    candidates = engine.discover(
         q,
-        extra_urls=merged_extra,
-        seed_domains=seed_domains,
-        budget=max(budget * 4, 40),
-        value_overrides=value_overrides,
+        limit=max(budget * 4, 40),
+        extra_seeds=merged_extra,
+        use_llm=use_llm,
+        model=model,
     )
     if not candidates:
         fallback = [
             f"https://{q.replace(' ', '')}.com",
             f"https://{q.replace(' ', '')}.io",
         ]
-        candidates = [Candidate(url=url, source="fallback", weight=0.1) for url in fallback]
+        candidates = [
+            Candidate(url=url, source="fallback", weight=0.1, score=0.1) for url in fallback
+        ]
     return candidates
 
 

--- a/server/discover.py
+++ b/server/discover.py
@@ -1,0 +1,520 @@
+"""Discovery helpers bridging registry seeds and learned web hints."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from rank.authority import AuthorityIndex
+from seed_loader.sources import SeedSource, discover_sources
+
+LOGGER = logging.getLogger(__name__)
+
+DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
+CURATED_VALUES_PATH = DATA_DIR / "seeds" / "curated_seeds.jsonl"
+
+VALUE_WEIGHT = float(os.getenv("DISCOVER_W_VALUE", "0.5"))
+FRESH_WEIGHT = float(os.getenv("DISCOVER_W_FRESH", "0.3"))
+AUTH_WEIGHT = float(os.getenv("DISCOVER_W_AUTH", "0.2"))
+BASE_WEIGHT = float(os.getenv("DISCOVER_BASE_WEIGHT", "1.0"))
+
+DEFAULT_PER_HOST = int(os.getenv("FRONTIER_PER_HOST", "3"))
+DEFAULT_POLITENESS_DELAY = float(os.getenv("FRONTIER_POLITENESS_DELAY", "1.0"))
+DEFAULT_RERANK_MARGIN = float(os.getenv("FRONTIER_RERANK_MARGIN", "0.15"))
+
+DEFAULT_LLM_MODEL = os.getenv("OLLAMA_MODEL", "llama3.1:8b-instruct")
+DEFAULT_LLM_TIMEOUT = float(os.getenv("OLLAMA_TIMEOUT", "30"))
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "for",
+    "from",
+    "how",
+    "in",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "what",
+    "where",
+    "why",
+}
+
+
+def _keywords(query: str) -> List[str]:
+    words = re.findall(r"[a-z0-9]+", query.lower())
+    filtered = [word for word in words if word not in _STOPWORDS]
+    return filtered or words
+
+
+def _sanitize_url(url: str, base_url: str | None = None) -> Optional[str]:
+    candidate = (url or "").strip()
+    if not candidate:
+        return None
+    if candidate.startswith("javascript:"):
+        return None
+    if candidate.startswith(("http://", "https://")):
+        probe = candidate
+    elif candidate.startswith("//"):
+        probe = "https:" + candidate
+    elif base_url:
+        probe = urljoin(base_url, candidate)
+    else:
+        probe = "https://" + candidate.lstrip("/")
+    try:
+        parsed = urlparse(probe)
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "https"
+    path = parsed.path or "/"
+    sanitized = f"{scheme}://{parsed.netloc}{path}"
+    if parsed.query:
+        sanitized = f"{sanitized}?{parsed.query}"
+    return sanitized.rstrip("/")
+
+
+def _domain_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def _heuristic_value(url: str) -> float:
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    score = 0.6
+    for keyword in ("docs", "documentation", "guide", "handbook"):
+        if keyword in path:
+            score += 0.25
+            break
+    if any(token in path for token in ("blog", "kb", "support")):
+        score += 0.1
+    if "api" in path:
+        score += 0.1
+    if parsed.netloc.lower().endswith((".org", ".io", ".dev")):
+        score += 0.1
+    return max(0.1, min(score, 1.5))
+
+
+def _freshness_hint(url: str, source: str) -> float:
+    lowered = url.lower()
+    if "sitemap" in lowered or source.startswith("sitemap"):
+        return 1.0
+    if any(token in lowered for token in ("rss", "atom", "feed")):
+        return 0.9
+    if "blog" in lowered or "news" in lowered:
+        return 0.6
+    return 0.2 if source == "seed" else 0.1
+
+
+def score_candidate(*, boost: float, value_prior: float, freshness: float, authority: float) -> float:
+    """Apply the weighted scoring model shared with the product brief."""
+
+    return (
+        BASE_WEIGHT * boost
+        + VALUE_WEIGHT * value_prior
+        + FRESH_WEIGHT * freshness
+        + AUTH_WEIGHT * authority
+    )
+
+
+def _default_learned_loader() -> Iterable[Mapping[str, object]]:
+    try:
+        from search import seeds as seed_store  # pylint: disable=import-outside-toplevel
+    except ImportError:  # pragma: no cover - circular import guard
+        return []
+    return seed_store.load_entries()
+
+
+@dataclass(slots=True)
+class DiscoveryHit:
+    """Intermediate hit enriched with semantic signals."""
+
+    url: str
+    source: str
+    boost: float = 1.0
+    value_prior: float | None = None
+    freshness: float | None = None
+    authority: float | None = None
+    score: float | None = None
+
+    def finalize(self, value_map: Mapping[str, float], authority: AuthorityIndex) -> "DiscoveryHit":
+        sanitized = _sanitize_url(self.url)
+        if not sanitized:
+            raise ValueError("invalid url")
+        domain = _domain_from_url(sanitized)
+        value = self.value_prior if self.value_prior is not None else value_map.get(domain, _heuristic_value(sanitized))
+        fresh = self.freshness if self.freshness is not None else _freshness_hint(sanitized, self.source)
+        auth = self.authority if self.authority is not None else authority.score_for(domain)
+        score = score_candidate(boost=self.boost, value_prior=value, freshness=fresh, authority=auth)
+        return DiscoveryHit(
+            url=sanitized,
+            source=self.source,
+            boost=self.boost,
+            value_prior=value,
+            freshness=fresh,
+            authority=auth,
+            score=score,
+        )
+
+
+def extract_links(html: str, *, base_url: str | None = None) -> List[str]:
+    """Return sanitized hyperlinks discovered in *html*."""
+
+    soup = BeautifulSoup(html or "", "html.parser")
+    results: List[str] = []
+    for anchor in soup.find_all("a", href=True):
+        sanitized = _sanitize_url(anchor.get("href", ""), base_url)
+        if sanitized and sanitized not in results:
+            results.append(sanitized)
+    return results
+
+
+def wikidata_candidates(entities: Sequence[Mapping[str, object]]) -> Iterator[DiscoveryHit]:
+    """Yield hits from Wikidata-style entity payloads."""
+
+    for entity in entities:
+        if not isinstance(entity, Mapping):
+            continue
+        urls: List[str] = []
+        site_links = entity.get("sitelinks")
+        if isinstance(site_links, Mapping):
+            for payload in site_links.values():
+                if isinstance(payload, Mapping):
+                    href = payload.get("url")
+                    if isinstance(href, str):
+                        urls.append(href)
+        claims = entity.get("claims")
+        if isinstance(claims, Mapping):
+            official = claims.get("P856") or claims.get("official_website")
+            if isinstance(official, str):
+                urls.append(official)
+            elif isinstance(official, Sequence):
+                for value in official:
+                    if isinstance(value, str):
+                        urls.append(value)
+        extras = entity.get("urls")
+        if isinstance(extras, Sequence):
+            for value in extras:
+                if isinstance(value, str):
+                    urls.append(value)
+        for raw in urls:
+            sanitized = _sanitize_url(raw)
+            if not sanitized:
+                continue
+            yield DiscoveryHit(url=sanitized, source="wikidata", boost=1.15)
+
+
+def github_candidates(repos: Sequence[Mapping[str, object]]) -> Iterator[DiscoveryHit]:
+    """Yield hits derived from GitHub repository metadata."""
+
+    for repo in repos:
+        if not isinstance(repo, Mapping):
+            continue
+        html_url = repo.get("html_url")
+        if isinstance(html_url, str):
+            urls = [html_url]
+            urls.append(html_url.rstrip("/") + "/wiki")
+            urls.append(html_url.rstrip("/") + "/tree/main/docs")
+            homepage = repo.get("homepage")
+            if isinstance(homepage, str) and homepage:
+                urls.append(homepage)
+            for url in urls:
+                sanitized = _sanitize_url(url)
+                if sanitized:
+                    yield DiscoveryHit(url=sanitized, source="github", boost=1.2)
+
+
+def sitemap_candidates(urls: Iterable[str], *, source: str = "sitemap-hint") -> Iterator[DiscoveryHit]:
+    """Wrap sitemap URLs as discovery hits."""
+
+    for url in urls:
+        sanitized = _sanitize_url(str(url))
+        if sanitized:
+            yield DiscoveryHit(url=sanitized, source=source, boost=1.1, freshness=1.0)
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+    from crawler.frontier import Candidate
+
+
+class LLMReranker:
+    """Thin wrapper around a local Ollama endpoint to rerank borderline URLs."""
+
+    def __init__(
+        self,
+        endpoint: str | None,
+        *,
+        model: str | None = None,
+        timeout: float | None = None,
+        transport: Callable[..., requests.Response] | None = None,
+    ) -> None:
+        self.endpoint = (endpoint or "").rstrip("/")
+        self.model = (model or DEFAULT_LLM_MODEL or "").strip()
+        self.timeout = timeout if timeout is not None else DEFAULT_LLM_TIMEOUT
+        self._transport = transport or requests.post
+
+    def __call__(self, query: str, candidates: List["Candidate"]) -> List["Candidate"]:
+        if not self.endpoint or not self.model or not candidates:
+            return candidates
+        prompt = self._prompt(query, candidates)
+        payload = {"model": self.model, "prompt": prompt, "stream": False}
+        try:
+            response = self._transport(
+                f"{self.endpoint}/api/generate",
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.debug("LLM rerank request failed: %s", exc)
+            return candidates
+        try:
+            body = response.json()
+            raw = (body or {}).get("response", "").strip()
+            order = json.loads(raw)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.debug("LLM rerank response invalid: %s", exc)
+            return candidates
+        if not isinstance(order, list):
+            return candidates
+        index: Dict[str, int] = {}
+        for position, url in enumerate(order):
+            if isinstance(url, str):
+                index[url.strip()] = position
+        if not index:
+            return candidates
+        return sorted(candidates, key=lambda c: index.get(c.url, len(index)))
+
+    @staticmethod
+    def _prompt(query: str, candidates: Sequence["Candidate"]) -> str:
+        bullet = "\n".join(f"- {candidate.url}" for candidate in candidates)
+        return (
+            "Rank the following documentation URLs for answering the query:\n"
+            f"Query: {query}\n"
+            f"URLs:\n{bullet}\n"
+            "Respond with a JSON array listing the URLs from best to worst."
+        )
+
+
+class DiscoveryEngine:
+    """Central orchestrator for focused crawl seed discovery."""
+
+    def __init__(
+        self,
+        *,
+        registry_loader: Callable[[Sequence[str] | None], List[SeedSource]] = discover_sources,
+        learned_loader: Callable[[], Iterable[Mapping[str, object]]] = _default_learned_loader,
+        authority_factory: Callable[[], AuthorityIndex] = AuthorityIndex.load_default,
+        per_host_cap: int | None = None,
+        politeness_delay: float | None = None,
+        rerank_margin: float | None = None,
+    ) -> None:
+        self._registry_loader = registry_loader
+        self._learned_loader = learned_loader
+        self._authority_factory = authority_factory
+        self._per_host_cap = DEFAULT_PER_HOST if per_host_cap is None else max(1, int(per_host_cap))
+        self._politeness_delay = DEFAULT_POLITENESS_DELAY if politeness_delay is None else max(0.0, float(politeness_delay))
+        self._rerank_margin = DEFAULT_RERANK_MARGIN if rerank_margin is None else max(0.0, float(rerank_margin))
+        self._authority: AuthorityIndex | None = None
+        self._registry_cache: List[SeedSource] | None = None
+        self._value_map: Dict[str, float] | None = None
+        self._learned_cache: List[Mapping[str, object]] | None = None
+
+    # ------------------------------------------------------------------
+    # Cached loaders
+    # ------------------------------------------------------------------
+    def _authority_index(self) -> AuthorityIndex:
+        if self._authority is None:
+            self._authority = self._authority_factory()
+        return self._authority
+
+    def _registry(self) -> List[SeedSource]:
+        if self._registry_cache is None:
+            try:
+                self._registry_cache = self._registry_loader(None)
+            except Exception:  # pragma: no cover - defensive
+                LOGGER.debug("registry loader failed", exc_info=True)
+                self._registry_cache = []
+        return list(self._registry_cache)
+
+    def _learned(self) -> List[Mapping[str, object]]:
+        if self._learned_cache is None:
+            try:
+                self._learned_cache = list(self._learned_loader())
+            except Exception:  # pragma: no cover - defensive
+                LOGGER.debug("learned loader failed", exc_info=True)
+                self._learned_cache = []
+        return list(self._learned_cache)
+
+    def _value_map_cached(self) -> Dict[str, float]:
+        if self._value_map is None:
+            mapping: Dict[str, float] = {}
+            mapping.update(self._load_curated_values())
+            for entry in self._learned():
+                domain = (entry.get("domain") or "").strip().lower()
+                if not domain:
+                    continue
+                try:
+                    score = float(entry.get("score", 0.0))
+                except (TypeError, ValueError):
+                    score = 0.0
+                mapping[domain] = max(mapping.get(domain, 0.0), score)
+            self._value_map = mapping
+        return dict(self._value_map)
+
+    @staticmethod
+    def _load_curated_values() -> Dict[str, float]:
+        values: Dict[str, float] = {}
+        if not CURATED_VALUES_PATH.exists():
+            return values
+        try:
+            with CURATED_VALUES_PATH.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    text = line.strip()
+                    if not text:
+                        continue
+                    try:
+                        payload = json.loads(text)
+                    except json.JSONDecodeError:
+                        continue
+                    url = payload.get("url")
+                    if not isinstance(url, str):
+                        continue
+                    domain = _domain_from_url(url)
+                    try:
+                        score = float(payload.get("value_prior", 0.0))
+                    except (TypeError, ValueError):
+                        score = 0.0
+                    values[domain] = max(values.get(domain, 0.0), score)
+        except OSError:  # pragma: no cover - filesystem issues
+            return values
+        return values
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def discover(
+        self,
+        query: str,
+        *,
+        limit: int,
+        extra_seeds: Optional[Sequence[str]] = None,
+        html_snippets: Optional[Sequence[str]] = None,
+        wikidata_entities: Optional[Sequence[Mapping[str, object]]] = None,
+        github_repos: Optional[Sequence[Mapping[str, object]]] = None,
+        sitemap_urls: Optional[Sequence[Iterable[str]]] = None,
+        use_llm: bool = False,
+        model: Optional[str] = None,
+        rerank_fn: Optional[Callable[[str, List["Candidate"]], List["Candidate"]]] = None,
+    ) -> List["Candidate"]:
+        """Return ranked crawl seeds for *query*."""
+
+        q = (query or "").strip()
+        if not q:
+            return []
+        limit = max(1, int(limit))
+        keywords = set(_keywords(q))
+
+        hits: List[DiscoveryHit] = []
+
+        for source in self._registry():
+            url = getattr(source, "url", None)
+            if not isinstance(url, str):
+                continue
+            if keywords and not any(token in url.lower() for token in keywords):
+                continue
+            hits.append(DiscoveryHit(url=url, source=source.source or "seed", boost=1.05))
+
+        for entry in self._learned():
+            domain = (entry.get("domain") or "").strip()
+            if not domain:
+                continue
+            url = entry.get("url")
+            if isinstance(url, str) and url.strip():
+                target = url
+            else:
+                target = f"https://{domain}"
+            try:
+                score = float(entry.get("score", 0.0))
+            except (TypeError, ValueError):
+                score = 0.0
+            hits.append(DiscoveryHit(url=target, source="learned", boost=1.1, value_prior=score))
+
+        for snippet in html_snippets or []:
+            for url in extract_links(snippet):
+                hits.append(DiscoveryHit(url=url, source="html", boost=1.2))
+
+        for url in extra_seeds or []:
+            sanitized = _sanitize_url(url)
+            if sanitized:
+                hits.append(DiscoveryHit(url=sanitized, source="manual", boost=1.25))
+
+        if wikidata_entities:
+            hits.extend(list(wikidata_candidates(wikidata_entities)))
+
+        if github_repos:
+            hits.extend(list(github_candidates(github_repos)))
+
+        if sitemap_urls:
+            for group in sitemap_urls:
+                hits.extend(list(sitemap_candidates(group)))
+
+        authority = self._authority_index()
+        value_map = self._value_map_cached()
+
+        deduped: Dict[str, DiscoveryHit] = {}
+        for hit in hits:
+            try:
+                finalized = hit.finalize(value_map, authority)
+            except ValueError:
+                continue
+            existing = deduped.get(finalized.url)
+            if existing is None or (finalized.score or 0.0) > (existing.score or 0.0):
+                deduped[finalized.url] = finalized
+
+        discovery_hints = list(deduped.values())
+        if not discovery_hints:
+            return []
+
+        if rerank_fn is None and use_llm:
+            rerank_fn = LLMReranker(os.getenv("OLLAMA_URL", os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")), model=model)
+
+        from crawler.frontier import build_frontier  # local import to avoid cycles
+
+        frontier = build_frontier(
+            q,
+            budget=limit,
+            discovery_hints=discovery_hints,
+            per_host_cap=self._per_host_cap,
+            politeness_delay=self._politeness_delay,
+            rerank_fn=rerank_fn,
+            rerank_margin=self._rerank_margin,
+        )
+        return frontier
+
+
+__all__ = [
+    "DiscoveryEngine",
+    "DiscoveryHit",
+    "LLMReranker",
+    "extract_links",
+    "github_candidates",
+    "sitemap_candidates",
+    "score_candidate",
+    "wikidata_candidates",
+]

--- a/tests/test_crawler_frontier.py
+++ b/tests/test_crawler_frontier.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from urllib.parse import urlparse
 
 import pytest
@@ -24,6 +25,7 @@ def test_crawler_frontier_applies_value_overrides_before_dedupe():
     )
 
     assert target.weight == pytest.approx(4.0)
+    assert target.score == pytest.approx(4.0)
 
 
 def test_crawler_frontier_legacy_arguments_still_supported():
@@ -42,3 +44,66 @@ def test_crawler_frontier_legacy_arguments_still_supported():
     )
 
     assert domain_candidate.weight == pytest.approx(1.5)
+    assert domain_candidate.score == pytest.approx(domain_candidate.weight)
+
+
+def test_crawler_frontier_enforces_host_cap():
+    hints = [
+        SimpleNamespace(url=f"https://preferred.com/docs/{idx}", source="seed", score=2.0, boost=1.0)
+        for idx in range(4)
+    ]
+    hints.extend(
+        [SimpleNamespace(url=f"https://alt{idx}.dev/docs", source="seed", score=1.5, boost=1.0) for idx in range(2)]
+    )
+
+    candidates = build_frontier(
+        "docs",
+        discovery_hints=hints,
+        budget=5,
+        per_host_cap=2,
+    )
+
+    preferred = [c for c in candidates if urlparse(c.url).netloc == "preferred.com"]
+    assert len(preferred) == 2
+
+
+def test_crawler_frontier_politeness_delay_sets_available_at():
+    hints = [
+        SimpleNamespace(url=f"https://timed.dev/docs/{idx}", source="seed", score=3.0 - idx * 0.1, boost=1.0)
+        for idx in range(3)
+    ]
+    candidates = build_frontier(
+        "timed",
+        discovery_hints=hints,
+        budget=3,
+        per_host_cap=3,
+        politeness_delay=5.0,
+        now=0.0,
+    )
+    times = [c.available_at for c in candidates]
+    assert times == [0.0, 5.0, 10.0]
+
+
+def test_crawler_frontier_reranks_borderline_candidates():
+    hints = [
+        SimpleNamespace(url=f"https://rr{i}.dev/docs", source="seed", score=1.0 + i * 0.01, boost=1.0)
+        for i in range(4)
+    ]
+
+    def rerank(query, items):
+        assert query == "rr"
+        return list(reversed(items))
+
+    candidates = build_frontier(
+        "rr",
+        discovery_hints=hints,
+        budget=4,
+        per_host_cap=4,
+        rerank_fn=rerank,
+        rerank_margin=0.5,
+    )
+
+    assert [c.url for c in candidates[:2]] == [
+        "https://rr0.dev/docs",
+        "https://rr1.dev/docs",
+    ]

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,106 @@
+import json
+from typing import Iterable, Mapping
+
+import pytest
+
+import server.discover as discover
+from crawler.frontier import Candidate
+from server.discover import DiscoveryEngine, LLMReranker, extract_links, score_candidate
+
+
+def test_extract_links_handles_relative_urls():
+    html = """
+    <html><body>
+        <a href="https://example.com/docs/">Docs</a>
+        <a href="/guides/intro">Guide</a>
+        <a href="javascript:void(0)">Skip</a>
+    </body></html>
+    """
+    links = extract_links(html, base_url="https://example.com")
+    assert links == [
+        "https://example.com/docs",
+        "https://example.com/guides/intro",
+    ]
+
+
+def test_score_candidate_respects_weights():
+    value = score_candidate(boost=1.0, value_prior=1.0, freshness=0.5, authority=0.25)
+    expected = (
+        discover.BASE_WEIGHT * 1.0
+        + discover.VALUE_WEIGHT * 1.0
+        + discover.FRESH_WEIGHT * 0.5
+        + discover.AUTH_WEIGHT * 0.25
+    )
+    assert value == pytest.approx(expected)
+
+
+class StubAuthority:
+    def __init__(self, scores: Mapping[str, float]) -> None:
+        self.scores = scores
+
+    def score_for(self, host: str) -> float:
+        return self.scores.get(host, 0.0)
+
+
+class StubSeed:
+    def __init__(self, url: str, source: str = "seed") -> None:
+        self.url = url
+        self.source = source
+        self.tags: set[str] = set()
+
+
+def test_discovery_engine_merges_sources(monkeypatch):
+    def fake_registry(_: Iterable[str] | None) -> list[StubSeed]:
+        return [StubSeed("https://docs.alpha.dev"), StubSeed("https://beta.dev")]
+
+    learned = [
+        {"domain": "gamma.dev", "score": 1.2, "url": "https://gamma.dev/docs"},
+    ]
+
+    engine = DiscoveryEngine(
+        registry_loader=fake_registry,
+        learned_loader=lambda: learned,
+        authority_factory=lambda: StubAuthority({"docs.alpha.dev": 0.5, "gamma.dev": 0.2}),
+        per_host_cap=3,
+        politeness_delay=0.0,
+    )
+
+    frontier = engine.discover(
+        "alpha",
+        limit=5,
+        extra_seeds=["https://handbook.alpha.dev"],
+        use_llm=False,
+    )
+
+    urls = [candidate.url for candidate in frontier]
+    assert any(url.startswith("https://docs.alpha.dev") for url in urls)
+    assert any("gamma.dev" in url for url in urls)
+    assert all(candidate.score is not None for candidate in frontier)
+
+
+def test_llm_reranker_orders_candidates(monkeypatch):
+    class DummyResponse:
+        def __init__(self, order):
+            self._order = order
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": json.dumps(self._order)}
+
+    calls = {}
+
+    def fake_transport(url, *, json, timeout):
+        calls["url"] = url
+        return DummyResponse(["https://b.dev", "https://a.dev"])
+
+    reranker = LLMReranker("http://localhost:11434", model="stub", transport=fake_transport)
+    candidates = [
+        Candidate(url="https://a.dev", source="seed", weight=1.0, score=1.0),
+        Candidate(url="https://b.dev", source="seed", weight=1.0, score=1.0),
+    ]
+
+    ranked = reranker("query", candidates)
+    assert ranked[0].url == "https://b.dev"
+    assert calls["url"].endswith("/api/generate")


### PR DESCRIPTION
## Summary
- add a discovery engine module with registry/learned hints, HTML/Wikidata/GitHub/sitemap shims, and LLM reranking support
- route focused crawl seed selection through the new discovery engine and propagate candidate scores to the crawler
- harden the frontier with per-host caps, politeness delays, and optional LLM reranking plus corresponding test coverage

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0c66161748321ae50b075b9e83d63