### PR TITLE
feat: gate focused crawl on confidence and reuse learned seeds

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,6 +30,9 @@ class AppConfig:
     focused_budget: int
     smart_min_results: int
     smart_trigger_cooldown: int
+    smart_confidence_threshold: float
+    smart_seed_min_similarity: float
+    smart_seed_limit: int
     search_default_limit: int
     search_max_limit: int
     max_query_length: int
@@ -54,6 +57,9 @@ class AppConfig:
         focused_budget = max(1, int(os.getenv("FOCUSED_CRAWL_BUDGET", "10")))
         smart_min_results = max(0, int(os.getenv("SMART_MIN_RESULTS", "1")))
         smart_trigger_cooldown = max(0, int(os.getenv("SMART_TRIGGER_COOLDOWN", "900")))
+        smart_confidence_threshold = float(os.getenv("SMART_CONFIDENCE_THRESHOLD", "0.35"))
+        smart_seed_min_similarity = float(os.getenv("SMART_SEED_MIN_SIMILARITY", "0.35"))
+        smart_seed_limit = max(0, int(os.getenv("SMART_SEED_LIMIT", "12")))
         search_default_limit = max(1, int(os.getenv("SEARCH_DEFAULT_LIMIT", "20")))
         search_max_limit = max(search_default_limit, int(os.getenv("SEARCH_MAX_LIMIT", "50")))
         max_query_length = max(32, int(os.getenv("SEARCH_MAX_QUERY_LENGTH", "256")))
@@ -74,6 +80,9 @@ class AppConfig:
             focused_budget=focused_budget,
             smart_min_results=smart_min_results,
             smart_trigger_cooldown=smart_trigger_cooldown,
+            smart_confidence_threshold=smart_confidence_threshold,
+            smart_seed_min_similarity=smart_seed_min_similarity,
+            smart_seed_limit=smart_seed_limit,
             search_default_limit=search_default_limit,
             search_max_limit=search_max_limit,
             max_query_length=max_query_length,
@@ -102,6 +111,9 @@ class AppConfig:
             "focused_budget": self.focused_budget,
             "smart_min_results": self.smart_min_results,
             "smart_trigger_cooldown": self.smart_trigger_cooldown,
+            "smart_confidence_threshold": self.smart_confidence_threshold,
+            "smart_seed_min_similarity": self.smart_seed_min_similarity,
+            "smart_seed_limit": self.smart_seed_limit,
             "search_default_limit": self.search_default_limit,
             "search_max_limit": self.search_max_limit,
             "max_query_length": self.max_query_length,

--- a/backend/app/search/embedding.py
+++ b/backend/app/search/embedding.py
@@ -1,0 +1,72 @@
+"""Lightweight query embedding helpers used by :mod:`SearchService`."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from typing import Sequence
+
+__all__ = ["embed_query", "cosine_similarity"]
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Return lowercase alphanumeric tokens extracted from *text*."""
+
+    if not text:
+        return []
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _bucket_index(token: str, dimensions: int) -> int:
+    digest = hashlib.sha256(token.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % dimensions
+
+
+def embed_query(text: str, *, dimensions: int = 64) -> list[float]:
+    """Return a deterministic embedding vector for ``text``.
+
+    The implementation intentionally avoids external dependencies so unit tests
+    remain lightweight.  Tokens are hashed into a fixed-size bucketed vector and
+    L2 normalised, which is sufficient for cosine similarity comparisons when
+    bootstrapping frontiers from past discoveries.
+    """
+
+    dims = max(8, int(dimensions))
+    vector = [0.0] * dims
+    tokens = _tokenize(text)
+    if not tokens:
+        return vector
+    for token in tokens:
+        idx = _bucket_index(token, dims)
+        vector[idx] += 1.0
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+def cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    """Return the cosine similarity between two vectors."""
+
+    if not left or not right:
+        return 0.0
+    length = min(len(left), len(right))
+    if length == 0:
+        return 0.0
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for idx in range(length):
+        lv = float(left[idx])
+        rv = float(right[idx])
+        dot += lv * rv
+        left_norm += lv * lv
+        right_norm += rv * rv
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    denominator = math.sqrt(left_norm) * math.sqrt(right_norm)
+    if denominator == 0.0:
+        return 0.0
+    return max(-1.0, min(dot / denominator, 1.0))
+

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from search import query as query_module
 from rank import blend_results, maybe_rerank
@@ -13,6 +13,7 @@ from ..config import AppConfig
 from ..indexer.incremental import ensure_index
 from ..jobs.focused_crawl import FocusedCrawlManager
 from ..metrics import metrics
+from .embedding import embed_query
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +34,23 @@ class SearchService:
             self._index_dir = self.config.index_dir
             return self._index
 
+    def _estimate_confidence(self, results: Sequence[dict]) -> float:
+        if not results:
+            return 0.0
+        top_score = 0.0
+        for item in results:
+            blended = item.get("blended_score")
+            base = item.get("score")
+            try:
+                candidate = float(blended if blended is not None else base or 0.0)
+            except (TypeError, ValueError):
+                candidate = 0.0
+            if candidate > top_score:
+                top_score = candidate
+        if top_score <= 0:
+            return 0.0
+        return max(0.0, min(top_score / (1.0 + top_score), 1.0))
+
     def run_query(
         self,
         query: str,
@@ -40,7 +58,7 @@ class SearchService:
         limit: int,
         use_llm: Optional[bool],
         model: Optional[str],
-    ) -> Tuple[list[dict], Optional[str]]:
+    ) -> Tuple[list[dict], Optional[str], dict]:
         start = time.perf_counter()
         ix = self._get_index()
         results = query_module.search(
@@ -64,14 +82,51 @@ class SearchService:
 
         job_id: Optional[str] = None
         triggered = False
+        confidence_threshold = getattr(self.config, "smart_confidence_threshold", 0.25)
+        min_similarity = getattr(self.config, "smart_seed_min_similarity", 0.35)
+        seed_limit = getattr(self.config, "smart_seed_limit", 8)
+        confidence = self._estimate_confidence(blended)
+        trigger_reason: Optional[str] = None
+        frontier_seeds: Sequence[str] | None = None
         if q:
             effective_use_llm = llm_enabled
-            job_id = self.manager.schedule(q, effective_use_llm, model)
-            triggered = bool(job_id)
-            if triggered:
-                metrics.record_focused_enqueue()
+            should_trigger = len(blended) == 0 or confidence < confidence_threshold
+            query_embedding: Optional[Sequence[float]] = None
+            if should_trigger:
+                trigger_reason = "no_results" if not blended else "low_confidence"
+                query_embedding = embed_query(q)
+                try:
+                    if getattr(self.manager, "db", None) is not None:
+                        seeds = self.manager.db.similar_discovery_seeds(
+                            query_embedding,
+                            limit=int(seed_limit),
+                            min_similarity=float(min_similarity),
+                        )
+                        frontier_seeds = seeds
+                except Exception:  # pragma: no cover - defensive logging only
+                    LOGGER.debug("failed to query learned seeds for '%s'", q, exc_info=True)
+            if should_trigger:
+                job_id = self.manager.schedule(
+                    q,
+                    effective_use_llm,
+                    model,
+                    frontier_seeds=frontier_seeds,
+                    query_embedding=query_embedding,
+                )
+                triggered = bool(job_id)
+                if triggered:
+                    metrics.record_focused_enqueue()
+                else:
+                    trigger_reason = None
         metrics.record_query_event(len(blended), triggered, duration_ms)
-        return blended, job_id
+        seed_count = len(frontier_seeds) if triggered and frontier_seeds else 0
+        context = {
+            "confidence": confidence,
+            "triggered": triggered,
+            "trigger_reason": trigger_reason,
+            "seed_count": seed_count,
+        }
+        return blended, job_id, context
 
     def last_index_time(self) -> int:
         return self.manager.last_index_time()

--- a/tests/api/test_search_api.py
+++ b/tests/api/test_search_api.py
@@ -118,6 +118,7 @@ def test_search_service_endpoint_returns_job_id_with_results():
                     }
                 ],
                 "job-123",
+                {"confidence": 0.1, "triggered": True, "trigger_reason": "no_results", "seed_count": 0},
             )
 
         def last_index_time(self) -> int:
@@ -142,6 +143,7 @@ def test_search_service_endpoint_returns_job_id_with_results():
     assert payload["results"][0]["url"] == "https://docs.example.com"
     assert payload["last_index_time"] == search_service.last_index_time()
     assert search_service.calls == [("docs", 5, False, None)]
+    assert "confidence" in payload
 
 
 def test_search_returns_answer_and_results():


### PR DESCRIPTION
## Summary
- trigger focused crawls only when the blended query results are empty or fall below a configurable confidence threshold
- bootstrap new crawl jobs with learned-web query embeddings and discovery seeds, including a deterministic local embedding helper and persistence primitives
- expose crawl trigger context through /api/search and expand coverage with new unit tests for SearchService and the learned web database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0cbbe97ec83219b5492498687088e