### PR TITLE
Enhance manual refresh workflow with frontier controls and embedding pipeline

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,6 +121,17 @@ app.config.update(
     RAG_EMBED_MANAGER=embed_manager,
 )
 
+worker = app.config.get("REFRESH_WORKER")
+if worker is not None:
+    try:
+        worker.configure_vector_pipeline(
+            vector_store=vector_store,
+            embedder=embedder,
+            chunker=chunker,
+        )
+    except AttributeError:  # pragma: no cover - defensive guard for legacy worker
+        logging.getLogger(__name__).debug("Refresh worker does not support vector pipeline configuration", exc_info=True)
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -58,7 +58,7 @@ def create_app() -> Flask:
     runner = JobRunner(config.logs_dir)
     manager = FocusedCrawlManager(config, runner, db)
     search_service = SearchService(config, manager)
-    refresh_worker = RefreshWorker(config)
+    refresh_worker = RefreshWorker(config, search_service=search_service)
 
     app.config.update(
         APP_CONFIG=config,

--- a/backend/app/api/refresh.py
+++ b/backend/app/api/refresh.py
@@ -30,8 +30,59 @@ def trigger_refresh():
     else:
         model = None
 
+    def _parse_positive_int(value: object, field: str) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(field)
+        try:
+            numeric = int(value)
+        except (TypeError, ValueError):
+            raise ValueError(field) from None
+        if numeric <= 0:
+            raise ValueError(field)
+        return numeric
+
     try:
-        job_id, status, created = worker.enqueue(query, use_llm=use_llm, model=model)
+        budget = _parse_positive_int(payload.get("budget"), "budget")
+        depth = _parse_positive_int(payload.get("depth"), "depth")
+    except ValueError as exc:
+        return jsonify({"error": f"invalid_{exc.args[0]}"}), 400
+
+    force_raw = payload.get("force")
+    force = bool(force_raw) if force_raw is not None else False
+
+    seeds_payload = payload.get("seeds")
+    seeds: list[str] | None
+    if seeds_payload is None:
+        seeds = None
+    else:
+        seeds_list: list[str] = []
+        if isinstance(seeds_payload, str):
+            candidate = seeds_payload.strip()
+            if candidate:
+                seeds_list.append(candidate)
+        elif isinstance(seeds_payload, (list, tuple)):
+            for item in seeds_payload:
+                if not isinstance(item, str):
+                    return jsonify({"error": "invalid_seeds"}), 400
+                candidate = item.strip()
+                if candidate:
+                    seeds_list.append(candidate)
+        else:
+            return jsonify({"error": "invalid_seeds"}), 400
+        seeds = seeds_list
+
+    try:
+        job_id, status, created = worker.enqueue(
+            query,
+            use_llm=use_llm,
+            model=model,
+            budget=budget,
+            depth=depth,
+            force=force,
+            seeds=seeds,
+        )
     except ValueError as exc:
         return jsonify({"error": "invalid_query", "detail": str(exc)}), 400
 

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -75,3 +75,10 @@ class SearchService:
 
     def last_index_time(self) -> int:
         return self.manager.last_index_time()
+
+    def invalidate_index(self) -> None:
+        """Drop cached Whoosh index handle so future queries reopen it."""
+
+        with self._lock:
+            self._index = None
+            self._index_dir = None

--- a/server/refresh_worker.py
+++ b/server/refresh_worker.py
@@ -2,21 +2,41 @@
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import queue
 import threading
 import time
 import uuid
 from collections import deque
-from typing import Deque, Dict, Optional
+from typing import TYPE_CHECKING, Deque, Dict, Optional, Sequence
+from urllib.parse import urlparse
 
 from backend.app.config import AppConfig
 from backend.app.jobs.focused_crawl import run_focused_crawl
+from crawler.frontier import Candidate
+from server.discover import DiscoveryEngine
+
+if TYPE_CHECKING:  # pragma: no cover - import cycles avoided at runtime
+    from backend.app.search.service import SearchService
+    from engine.data.store import VectorStore
+    from engine.indexing.chunk import TokenChunker
+    from engine.indexing.embed import OllamaEmbedder
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class RefreshWorker:
     """Track and execute manual refresh jobs serially."""
 
-    def __init__(self, config: AppConfig, *, max_history: int = 20) -> None:
+    def __init__(
+        self,
+        config: AppConfig,
+        *,
+        max_history: int = 20,
+        search_service: "SearchService" | None = None,
+    ) -> None:
         self.config = config
         self.max_history = max_history
         self._queue: "queue.Queue[str]" = queue.Queue()
@@ -24,22 +44,42 @@ class RefreshWorker:
         self._query_to_job: Dict[str, str] = {}
         self._history: Deque[str] = deque(maxlen=max_history)
         self._lock = threading.RLock()
+        self._search_service = search_service
+        self._discovery = DiscoveryEngine()
+        self._vector_store: "VectorStore | None" = None
+        self._embedder: "OllamaEmbedder | None" = None
+        self._chunker: "TokenChunker | None" = None
+        self._frontier_depth_default = 4
         self._worker = threading.Thread(target=self._worker_loop, name="refresh-worker", daemon=True)
         self._worker.start()
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def enqueue(self, query: str, *, use_llm: bool = False, model: Optional[str] = None) -> tuple[str, dict, bool]:
+    def enqueue(
+        self,
+        query: str,
+        *,
+        use_llm: bool = False,
+        model: Optional[str] = None,
+        budget: Optional[int] = None,
+        depth: Optional[int] = None,
+        force: bool = False,
+        seeds: Optional[Sequence[str]] = None,
+    ) -> tuple[str, dict, bool]:
         """Queue a refresh for *query*; return (job_id, status, created)."""
 
         normalized = self._normalize_query(query)
         if not normalized:
             raise ValueError("Query must be a non-empty string")
 
+        job_budget = self._coerce_positive_int(budget)
+        job_depth = self._coerce_positive_int(depth)
+        seed_list = self._sanitize_seeds(seeds)
+
         with self._lock:
             existing_id = self._query_to_job.get(normalized)
-            if existing_id:
+            if existing_id and not force:
                 existing = self._jobs.get(existing_id)
                 if existing and existing.get("state") in {"queued", "running"}:
                     return existing_id, self._snapshot(existing), False
@@ -56,25 +96,50 @@ class RefreshWorker:
                 "progress": 0,
                 "use_llm": bool(use_llm),
                 "model": model,
+                "options": {
+                    "budget": job_budget,
+                    "depth": job_depth,
+                    "force": bool(force),
+                    "seeds": seed_list,
+                },
                 "created_at": now,
                 "started_at": None,
                 "updated_at": now,
                 "completed_at": None,
                 "stats": {
                     "seed_count": 0,
+                    "new_domains": 0,
                     "pages_fetched": 0,
+                    "fetched": 0,
                     "normalized_docs": 0,
                     "docs_indexed": 0,
+                    "updated": 0,
                     "skipped": 0,
                     "deduped": 0,
+                    "embedded": 0,
                 },
                 "result": None,
                 "error": None,
+                "frontier": None,
             }
             self._jobs[job_id] = record
             self._query_to_job[normalized] = job_id
             self._queue.put(job_id)
             return job_id, self._snapshot(record), True
+
+    def configure_vector_pipeline(
+        self,
+        *,
+        vector_store: "VectorStore | None" = None,
+        embedder: "OllamaEmbedder | None" = None,
+        chunker: "TokenChunker | None" = None,
+    ) -> None:
+        """Attach the optional embedding pipeline used for semantic refreshes."""
+
+        with self._lock:
+            self._vector_store = vector_store
+            self._embedder = embedder
+            self._chunker = chunker
 
     def status(self, *, job_id: Optional[str] = None, query: Optional[str] = None) -> dict:
         """Return a structured snapshot for a job or query."""
@@ -120,49 +185,101 @@ class RefreshWorker:
             job["message"] = "Starting refresh…"
             job["started_at"] = time.time()
             job["updated_at"] = job["started_at"]
+            options = dict(job.get("options") or {})
+            use_llm = bool(job.get("use_llm", False))
+            model = job.get("model")
+            query = job.get("query", "")
+
+        budget = self._effective_budget(options.get("budget"))
+        depth = self._effective_depth(options.get("depth"))
+        manual_seeds: Sequence[str] = options.get("seeds", [])
+
+        seed_candidates, frontier_meta = self._prepare_frontier(
+            query,
+            budget=budget,
+            depth=depth,
+            use_llm=use_llm,
+            model=model,
+            manual_seeds=manual_seeds,
+        )
+
+        if frontier_meta:
+            with self._lock:
+                job = self._jobs.get(job_id)
+                if job:
+                    job["frontier"] = frontier_meta
+                    stats = dict(job.get("stats", {}))
+                    stats["seed_count"] = frontier_meta.get("seed_count", stats.get("seed_count", 0))
+                    stats["new_domains"] = frontier_meta.get("new_domains", stats.get("new_domains", 0))
+                    job["stats"] = stats
 
         def _progress(stage: str, payload: dict) -> None:
             self._handle_progress(job_id, stage, payload)
 
         try:
             result = run_focused_crawl(
-                job["query"],
-                self.config.focused_budget,
-                job.get("use_llm", False),
-                job.get("model"),
+                query,
+                budget,
+                use_llm,
+                model,
                 config=self.config,
                 progress_callback=_progress,
+                seed_candidates=seed_candidates,
+                frontier_depth=depth,
             )
         except Exception as exc:  # pragma: no cover - defensive path
+            LOGGER.exception("refresh job failed for '%s'", query, exc_info=True)
             self._mark_error(job_id, str(exc))
             return
+
+        normalized_docs = result.get("normalized_docs", [])
+        embedded = 0
+        if normalized_docs and self._vector_pipeline_ready():
+            try:
+                _progress("embedding_start", {"docs": len(normalized_docs)})
+                embedded = self._embed_documents(normalized_docs)
+            except Exception:  # pragma: no cover - defensive logging only
+                LOGGER.exception("failed to embed documents for '%s'", query, exc_info=True)
+            finally:
+                _progress("embedding_complete", {"embedded": embedded})
+
+        discovery_meta = result.get("discovery") or frontier_meta
 
         with self._lock:
             job = self._jobs.get(job_id)
             if not job:
                 return
             stats = job.get("stats", {})
-            stats.update(
-                {
-                    "pages_fetched": result.get("pages_fetched", stats.get("pages_fetched", 0)),
-                    "docs_indexed": result.get("docs_indexed", stats.get("docs_indexed", 0)),
-                    "skipped": result.get("skipped", stats.get("skipped", 0)),
-                    "deduped": result.get("deduped", stats.get("deduped", 0)),
-                    "normalized_docs": len(result.get("normalized_docs", [])),
-                }
-            )
+            stats["pages_fetched"] = int(result.get("pages_fetched", stats.get("pages_fetched", 0)) or 0)
+            stats["fetched"] = stats["pages_fetched"]
+            stats["docs_indexed"] = int(result.get("docs_indexed", stats.get("docs_indexed", 0)) or 0)
+            stats["updated"] = stats["docs_indexed"]
+            stats["skipped"] = int(result.get("skipped", stats.get("skipped", 0)) or 0)
+            stats["deduped"] = int(result.get("deduped", stats.get("deduped", 0)) or 0)
+            stats["normalized_docs"] = int(len(normalized_docs))
+            stats["embedded"] = max(int(stats.get("embedded", 0) or 0), int(embedded))
+            if discovery_meta:
+                stats["seed_count"] = discovery_meta.get("seed_count", stats.get("seed_count", 0))
+                stats["new_domains"] = discovery_meta.get("new_domains", stats.get("new_domains", 0))
             job["stats"] = stats
             job["state"] = "done"
             job["stage"] = "complete"
             job["message"] = "Refresh complete."
             job["progress"] = 100
-            job["result"] = result
+            job_result = dict(result)
+            if discovery_meta:
+                job_result["discovery"] = discovery_meta
+            job_result["embedded"] = embedded
+            job["result"] = job_result
+            job["frontier"] = discovery_meta
             job["completed_at"] = time.time()
             job["updated_at"] = job["completed_at"]
             self._history.append(job_id)
             normalized = job.get("normalized_query")
             if normalized:
                 self._query_to_job.pop(normalized, None)
+
+        self._trigger_hot_reload()
 
     def _mark_error(self, job_id: str, error: str) -> None:
         with self._lock:
@@ -197,14 +314,24 @@ class RefreshWorker:
             stats = job.get("stats", {})
             if stage == "frontier_complete":
                 stats["seed_count"] = int(payload.get("seed_count", 0) or 0)
+                stats["new_domains"] = int(payload.get("new_domains", stats.get("new_domains", 0)) or 0)
+                frontier = dict(job.get("frontier") or {})
+                frontier.update(payload)
+                frontier.setdefault("seed_count", stats.get("seed_count", 0))
+                frontier.setdefault("new_domains", stats.get("new_domains", 0))
+                job["frontier"] = frontier
             elif stage == "crawl_complete":
                 stats["pages_fetched"] = int(payload.get("pages_fetched", 0) or 0)
+                stats["fetched"] = stats["pages_fetched"]
             elif stage == "normalize_complete":
                 stats["normalized_docs"] = int(payload.get("docs", 0) or 0)
             elif stage == "index_complete":
                 stats["docs_indexed"] = int(payload.get("docs_indexed", 0) or 0)
+                stats["updated"] = stats["docs_indexed"]
                 stats["skipped"] = int(payload.get("skipped", 0) or 0)
                 stats["deduped"] = int(payload.get("deduped", 0) or 0)
+            elif stage == "embedding_complete":
+                stats["embedded"] = int(payload.get("embedded", stats.get("embedded", 0)) or 0)
             job["stats"] = stats
 
     # ------------------------------------------------------------------
@@ -230,6 +357,10 @@ class RefreshWorker:
             payload["error"] = job.get("error")
         if job.get("result") is not None:
             payload["result"] = job.get("result")
+        if job.get("frontier"):
+            payload["frontier"] = dict(job.get("frontier"))
+        if job.get("options"):
+            payload["options"] = dict(job.get("options"))
         return payload
 
     @staticmethod
@@ -250,6 +381,8 @@ class RefreshWorker:
             "index_complete": 95,
             "index_skipped": 95,
             "frontier_empty": 90,
+            "embedding_start": 96,
+            "embedding_complete": 99,
         }
         return mapping.get(stage)
 
@@ -259,6 +392,12 @@ class RefreshWorker:
             return "Collecting crawl seeds…"
         if stage == "frontier_complete":
             count = int(payload.get("seed_count", 0) or 0)
+            domains = int(payload.get("new_domains", 0) or 0)
+            if domains:
+                return (
+                    f"Planned {count} seed URL{'s' if count != 1 else ''} "
+                    f"across {domains} domain{'s' if domains != 1 else ''}."
+                )
             return f"Planned {count} seed URL{'s' if count != 1 else ''}."
         if stage == "crawl_start":
             return "Crawling priority URLs…"
@@ -279,5 +418,201 @@ class RefreshWorker:
             return "No new documents were indexed."
         if stage == "frontier_empty":
             return "No candidate URLs available for this query."
+        if stage == "embedding_start":
+            docs = int(payload.get("docs", 0) or 0)
+            return f"Embedding {docs} normalized document{'s' if docs != 1 else ''}…"
+        if stage == "embedding_complete":
+            embedded = int(payload.get("embedded", 0) or 0)
+            return f"Embedded {embedded} document{'s' if embedded != 1 else ''}."
         return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _trigger_hot_reload(self) -> None:
+        service = self._search_service
+        if service is None:
+            return
+        try:
+            service.invalidate_index()
+        except AttributeError:  # pragma: no cover - legacy compatibility
+            LOGGER.debug("search service does not expose invalidate_index", exc_info=True)
+        except Exception:  # pragma: no cover - defensive logging only
+            LOGGER.exception("failed to hot-reload search index", exc_info=True)
+
+    def _vector_pipeline_ready(self) -> bool:
+        return bool(self._vector_store and self._embedder and self._chunker)
+
+    def _embed_documents(self, docs: Sequence[dict]) -> int:
+        vector_store = self._vector_store
+        embedder = self._embedder
+        chunker = self._chunker
+        if not vector_store or not embedder or not chunker:
+            return 0
+        embedded = 0
+        for doc in docs:
+            if not isinstance(doc, dict):
+                continue
+            url = (doc.get("url") or "").strip()
+            body = (doc.get("body") or "").strip()
+            if not url or not body:
+                continue
+            title = (doc.get("title") or "").strip() or url
+            content_hash = hashlib.sha256(body.encode("utf-8", errors="ignore")).hexdigest()
+            try:
+                if hasattr(vector_store, "needs_update") and not vector_store.needs_update(url, None, content_hash):
+                    continue
+            except Exception:  # pragma: no cover - logging only
+                LOGGER.debug("vector store needs_update failed for %s", url, exc_info=True)
+            try:
+                chunks = chunker.chunk_text(body)
+            except Exception:  # pragma: no cover - logging only
+                LOGGER.exception("failed to chunk document %s", url, exc_info=True)
+                continue
+            if not chunks:
+                continue
+            try:
+                embeddings = embedder.embed_documents([chunk.text for chunk in chunks])
+            except Exception:  # pragma: no cover - logging only
+                LOGGER.exception("failed to embed document %s", url, exc_info=True)
+                continue
+            if not embeddings:
+                continue
+            try:
+                vector_store.upsert(
+                    url=url,
+                    title=title,
+                    etag=doc.get("etag"),
+                    content_hash=content_hash,
+                    chunks=chunks,
+                    embeddings=embeddings,
+                )
+            except Exception:  # pragma: no cover - logging only
+                LOGGER.exception("failed to upsert document %s", url, exc_info=True)
+                continue
+            embedded += 1
+        return embedded
+
+    def _prepare_frontier(
+        self,
+        query: str,
+        *,
+        budget: int,
+        depth: int,
+        use_llm: bool,
+        model: Optional[str],
+        manual_seeds: Sequence[str],
+    ) -> tuple[Optional[list[Candidate]], dict]:
+        manual_candidates = self._manual_seed_candidates(manual_seeds)
+        if manual_candidates:
+            metadata = self._seed_metadata(manual_candidates, budget=budget, depth=depth, mode="manual")
+            return manual_candidates, metadata
+
+        try:
+            limit = max(budget * depth, depth * 10)
+            discovered = list(
+                self._discovery.discover(
+                    query,
+                    limit=limit,
+                    use_llm=use_llm,
+                    model=model,
+                )
+            )
+        except Exception:  # pragma: no cover - defensive logging only
+            LOGGER.exception("discovery engine failed for '%s'", query, exc_info=True)
+            discovered = []
+
+        if discovered:
+            metadata = self._seed_metadata(discovered, budget=budget, depth=depth, mode="discovery")
+            return discovered, metadata
+
+        metadata = self._seed_metadata([], budget=budget, depth=depth, mode="discovery")
+        return None, metadata
+
+    def _manual_seed_candidates(self, seeds: Sequence[str]) -> list[Candidate]:
+        candidates: list[Candidate] = []
+        seen: set[str] = set()
+        for seed in seeds:
+            candidate = (seed or "").strip()
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            candidates.append(Candidate(url=candidate, source="manual", weight=1.25))
+        return candidates
+
+    def _seed_metadata(
+        self,
+        seeds: Sequence[Candidate],
+        *,
+        budget: int,
+        depth: int,
+        mode: str,
+    ) -> dict:
+        domains: set[str] = set()
+        for candidate in seeds:
+            try:
+                parsed = urlparse(candidate.url)
+            except Exception:
+                continue
+            host = (parsed.netloc or "").lower()
+            if host.startswith("www."):
+                host = host[4:]
+            if host:
+                domains.add(host)
+        preview = []
+        for candidate in list(seeds)[: min(len(seeds), 50)]:
+            preview.append(
+                {
+                    "url": candidate.url,
+                    "source": getattr(candidate, "source", "manual"),
+                    "score": getattr(candidate, "score", None),
+                    "weight": getattr(candidate, "weight", None),
+                }
+            )
+        return {
+            "mode": mode,
+            "budget": budget,
+            "depth": depth,
+            "seed_count": len(seeds),
+            "new_domains": len(domains),
+            "seeds": preview,
+        }
+
+    def _effective_budget(self, requested: Optional[int]) -> int:
+        numeric = self._coerce_positive_int(requested)
+        if numeric is None:
+            try:
+                return max(1, int(self.config.focused_budget))
+            except Exception:  # pragma: no cover - fallback for misconfigured budget
+                return 1
+        return numeric
+
+    def _effective_depth(self, requested: Optional[int]) -> int:
+        numeric = self._coerce_positive_int(requested)
+        if numeric is None:
+            return self._frontier_depth_default
+        return max(1, numeric)
+
+    @staticmethod
+    def _coerce_positive_int(value: Optional[int]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            numeric = int(value)
+        except (TypeError, ValueError):
+            return None
+        return numeric if numeric > 0 else None
+
+    @staticmethod
+    def _sanitize_seeds(seeds: Optional[Sequence[str]]) -> list[str]:
+        sanitized: list[str] = []
+        if not seeds:
+            return sanitized
+        for item in seeds:
+            if not isinstance(item, str):
+                continue
+            candidate = item.strip()
+            if candidate and candidate not in sanitized:
+                sanitized.append(candidate)
+        return sanitized
 

--- a/tests/test_cold_start.py
+++ b/tests/test_cold_start.py
@@ -7,7 +7,19 @@ from backend.app.config import AppConfig
 from backend.app.indexer.incremental import incremental_index
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    progress_callback=None,
+    db=None,
+    frontier_depth=None,
+    seed_candidates=None,
+):
     config.ensure_dirs()
     doc = {
         "url": f"https://local-doc/{query.replace(' ', '-')}",
@@ -33,6 +45,15 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "discovery": {
+            "seed_count": 1,
+            "new_domains": 1,
+            "mode": "manual" if seed_candidates else "discovery",
+            "depth": frontier_depth or 4,
+            "budget": budget,
+            "seeds": [],
+        },
+        "embedded": 0,
     }
 
 

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -24,7 +24,19 @@ def fake_ollama_request(url, model, system, prompt):
     return "# Research Report\n\n- Key point one[^1]\n- Key point two[^2]\n- Key point three[^3]\n\n[^1]: https://example.com/one\n[^2]: https://example.com/two\n[^3]: https://example.com/three"
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    progress_callback=None,
+    db=None,
+    frontier_depth=None,
+    seed_candidates=None,
+):
     config.ensure_dirs()
     doc = {
         "url": "https://example.com/one",
@@ -49,6 +61,15 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "discovery": {
+            "seed_count": 1,
+            "new_domains": 1,
+            "mode": "manual" if seed_candidates else "discovery",
+            "depth": frontier_depth or 4,
+            "budget": budget,
+            "seeds": [],
+        },
+        "embedded": 0,
     }
 
 


### PR DESCRIPTION
## Summary
- allow manual refresh API requests to pass budget, depth, seeds, and force flags through to the worker
- teach the refresh worker to record discovery metadata, reuse prepared frontiers, run optional embedding updates, and invalidate the search index cache
- update focused crawl discovery helpers and tests to surface new status metrics for fetched, updated, embedded, and new domains

## Testing
- pytest tests/api/test_refresh_api.py tests/test_cold_start.py tests/test_research.py

------
https://chatgpt.com/codex/tasks/task_e_68d0cc42b8f48321ac8f52be03694a65