### PR TITLE
Enhance refresh workflow controls and status

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -58,7 +58,7 @@ def create_app() -> Flask:
     runner = JobRunner(config.logs_dir)
     manager = FocusedCrawlManager(config, runner, db)
     search_service = SearchService(config, manager)
-    refresh_worker = RefreshWorker(config)
+    refresh_worker = RefreshWorker(config, search_service=search_service, db=db)
 
     app.config.update(
         APP_CONFIG=config,

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -34,6 +34,13 @@ class SearchService:
             self._index_dir = self.config.index_dir
             return self._index
 
+    def reload_index(self) -> None:
+        """Force the Whoosh index handle to be refreshed."""
+
+        with self._lock:
+            self._index = ensure_index(self.config.index_dir)
+            self._index_dir = self.config.index_dir
+
     def _estimate_confidence(self, results: Sequence[dict]) -> float:
         if not results:
             return 0.0

--- a/tests/api/test_refresh_api.py
+++ b/tests/api/test_refresh_api.py
@@ -19,11 +19,28 @@ def _patch_refresh_worker(monkeypatch: pytest.MonkeyPatch):
         *,
         config,
         extra_seeds=None,
+        manual_seeds=None,
+        frontier_depth=None,
+        query_embedding=None,
         progress_callback=None,
+        db=None,
     ):
         if progress_callback:
-            progress_callback("frontier_start", {"query": query})
-            progress_callback("frontier_complete", {"seed_count": 3})
+            progress_callback(
+                "frontier_start",
+                {"query": query, "mode": "discovery", "depth": frontier_depth, "budget": budget},
+            )
+            progress_callback(
+                "frontier_complete",
+                {
+                    "seed_count": 3,
+                    "mode": "discovery",
+                    "new_domains": 2,
+                    "embedded": 1,
+                    "seeds": ["https://example.com", "https://example.org"],
+                    "sources": {"manual": 1, "registry": 2},
+                },
+            )
             progress_callback("crawl_start", {"seed_count": 3})
         time.sleep(0.01)
         if progress_callback:
@@ -42,6 +59,16 @@ def _patch_refresh_worker(monkeypatch: pytest.MonkeyPatch):
             "duration": 0.05,
             "normalized_docs": [{}],
             "raw_path": None,
+            "embedded": 1,
+            "new_domains": 2,
+            "discovery": {
+                "mode": "discovery",
+                "seed_count": 3,
+                "sources": {"manual": 1, "registry": 2},
+                "seeds": ["https://example.com", "https://example.org"],
+                "budget": budget,
+                "depth": frontier_depth,
+            },
         }
 
     monkeypatch.setattr(refresh_worker, "run_focused_crawl", fake_run)
@@ -73,6 +100,11 @@ def test_refresh_flow_and_status_polling():
     assert final["state"] == "done"
     assert final["stats"]["docs_indexed"] == 1
     assert final["stats"]["pages_fetched"] == 2
+    assert final["stats"]["fetched"] == 2
+    assert final["stats"]["updated"] == 1
+    assert final["stats"]["embedded"] == 1
+    assert final["stats"]["new_domains"] == 2
+    assert final.get("discovery", {}).get("seed_count") == 3
 
 
 def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
@@ -87,7 +119,11 @@ def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
         *,
         config,
         extra_seeds=None,
+        manual_seeds=None,
+        frontier_depth=None,
+        query_embedding=None,
         progress_callback=None,
+        db=None,
     ):
         if progress_callback:
             progress_callback("frontier_start", {"query": query})
@@ -123,6 +159,12 @@ def test_refresh_deduplicates_active_jobs(monkeypatch: pytest.MonkeyPatch):
     assert second_payload["job_id"] == job_id
     assert second_payload["created"] is False
     assert second_payload["deduplicated"] is True
+
+    forced = client.post("/api/refresh", json={"query": "dedupe me", "force": True})
+    assert forced.status_code == 202
+    forced_payload = forced.get_json()
+    assert forced_payload["created"] is True
+    assert forced_payload["job_id"] != job_id
 
     release.set()
     deadline = time.time() + 2

--- a/tests/test_cold_start.py
+++ b/tests/test_cold_start.py
@@ -7,7 +7,20 @@ from backend.app.config import AppConfig
 from backend.app.indexer.incremental import incremental_index
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    manual_seeds=None,
+    frontier_depth=None,
+    query_embedding=None,
+    progress_callback=None,
+    db=None,
+):
     config.ensure_dirs()
     doc = {
         "url": f"https://local-doc/{query.replace(' ', '-')}",
@@ -33,6 +46,16 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "embedded": 0,
+        "new_domains": 0,
+        "discovery": {
+            "mode": "manual" if manual_seeds else "discovery",
+            "seed_count": 1,
+            "sources": {"manual" if manual_seeds else "registry": 1},
+            "seeds": [doc["url"]],
+            "budget": budget,
+            "depth": frontier_depth,
+        },
     }
 
 

--- a/tests/test_learned_web_db.py
+++ b/tests/test_learned_web_db.py
@@ -14,7 +14,7 @@ def test_learned_web_db_persists_discovery_and_pages(tmp_path) -> None:
 
     assert db.domain_value_map() == {}
 
-    domain_id = db.record_discovery(
+    domain_info = db.record_discovery(
         "test query",
         "https://example.com/docs",
         reason="frontier",
@@ -22,7 +22,9 @@ def test_learned_web_db_persists_discovery_and_pages(tmp_path) -> None:
         source="seed",
         discovered_at=123.0,
     )
-    assert domain_id is not None
+    assert domain_info is not None
+    domain_id, created = domain_info
+    assert created is True
 
     value_map = db.domain_value_map()
     assert value_map["example.com"] >= 1.2

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -24,7 +24,20 @@ def fake_ollama_request(url, model, system, prompt):
     return "# Research Report\n\n- Key point one[^1]\n- Key point two[^2]\n- Key point three[^3]\n\n[^1]: https://example.com/one\n[^2]: https://example.com/two\n[^3]: https://example.com/three"
 
 
-def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, extra_seeds=None):
+def fake_run_focused_crawl(
+    query,
+    budget,
+    use_llm,
+    model,
+    *,
+    config: AppConfig,
+    extra_seeds=None,
+    manual_seeds=None,
+    frontier_depth=None,
+    query_embedding=None,
+    progress_callback=None,
+    db=None,
+):
     config.ensure_dirs()
     doc = {
         "url": "https://example.com/one",
@@ -49,6 +62,16 @@ def fake_run_focused_crawl(query, budget, use_llm, model, *, config: AppConfig, 
         "duration": 0.01,
         "normalized_docs": [doc],
         "raw_path": None,
+        "embedded": 0,
+        "new_domains": 0,
+        "discovery": {
+            "mode": "manual" if manual_seeds else "discovery",
+            "seed_count": 1,
+            "sources": {"manual" if manual_seeds else "registry": 1},
+            "seeds": [doc["url"]],
+            "budget": budget,
+            "depth": frontier_depth,
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- add support for budget, depth, seeds, and force flags on the manual refresh API and job records
- extend the refresh worker to persist discovery metadata, propagate crawl options, reload the index, and expose richer stats
- teach the focused crawl pipeline and learned web store about manual seeds, discovery depth, embedded counts, and new domains while wiring the worker with the search service
- refresh related unit tests to cover the new API contract and job telemetry

## Testing
- pytest tests/api/test_refresh_api.py tests/test_learned_web_db.py tests/test_cold_start.py tests/test_research.py

------
https://chatgpt.com/codex/tasks/task_e_68d0d0e768308321a94f121f82865aec