### PR TITLE
Improve registry discovery fallback

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -12,19 +12,6 @@ from typing import Optional
 import requests
 from flask import Flask, jsonify, render_template, request
 
-from .api import chat as chat_api
-from .api import jobs as jobs_api
-from .api import metrics as metrics_api
-from .api import refresh as refresh_api
-from .api import research as research_api
-from .api import search as search_api
-from .config import AppConfig
-from .jobs.focused_crawl import FocusedCrawlManager
-from .jobs.runner import JobRunner
-from .metrics import metrics
-from .search.service import SearchService
-from server.refresh_worker import RefreshWorker
-from server.learned_web_db import get_db
 
 LOGGER = logging.getLogger(__name__)
 EMBEDDING_MODEL_PATTERNS = [
@@ -41,6 +28,22 @@ def _is_embedding_model(name: str) -> bool:
 
 
 def create_app() -> Flask:
+    from .api import chat as chat_api
+    from .api import jobs as jobs_api
+    from .api import metrics as metrics_api
+    from .api import refresh as refresh_api
+    from .api import research as research_api
+    from .api import search as search_api
+    from .config import AppConfig
+    from .jobs.focused_crawl import FocusedCrawlManager
+    from .jobs.runner import JobRunner
+    from .metrics import metrics as metrics_module
+    from .search.service import SearchService
+    from server.refresh_worker import RefreshWorker
+    from server.learned_web_db import get_db
+
+    metrics = metrics_module
+
     package_root = Path(__file__).resolve().parents[2]
     static_folder = package_root / "static"
     template_folder = package_root / "templates"

--- a/backend/app/jobs/focused_crawl.py
+++ b/backend/app/jobs/focused_crawl.py
@@ -8,9 +8,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence
-
-from crawler.frontier import Candidate
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Sequence
 from crawler.run import FocusedCrawler
 from server.discover import DiscoveryEngine
 
@@ -24,6 +22,9 @@ from backend.app.search.embedding import embed_query
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_DISCOVERY_DEPTH = 4
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from crawler.frontier import Candidate
 
 
 def run_focused_crawl(
@@ -257,6 +258,8 @@ def _get_seed_candidates(
     extra_seeds: Optional[Sequence[str]] = None,
     depth: Optional[int] = None,
 ) -> List[Candidate]:
+    from crawler.frontier import Candidate
+
     q = (query or "").strip()
     if not q:
         return []
@@ -285,6 +288,13 @@ def _get_seed_candidates(
         model=model,
     )
     if not candidates:
+        candidates = engine.registry_frontier(
+            q,
+            limit=limit,
+            use_llm=use_llm,
+            model=model,
+        )
+    if not candidates:
         fallback = [
             f"https://{q.replace(' ', '')}.com",
             f"https://{q.replace(' ', '')}.io",
@@ -296,6 +306,8 @@ def _get_seed_candidates(
 
 
 def _build_manual_candidates(seed_urls: Optional[Sequence[str]]) -> List[Candidate]:
+    from crawler.frontier import Candidate
+
     if not seed_urls:
         return []
     candidates: List[Candidate] = []

--- a/backend/app/jobs/research.py
+++ b/backend/app/jobs/research.py
@@ -11,9 +11,6 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from ..config import AppConfig
-from .focused_crawl import run_focused_crawl
-
-
 def _ollama_request(url: str, model: Optional[str], system: str, prompt: str) -> str:
     payload = {
         "messages": [
@@ -88,6 +85,8 @@ def run_research(query: str, model: Optional[str], budget: int, *, config: AppCo
     print(f"[research] plan: {json.dumps(plan, ensure_ascii=False)}")
 
     extra_sources = [url for url in plan.get("sources", []) if isinstance(url, str)]
+    from .focused_crawl import run_focused_crawl
+
     stats = run_focused_crawl(
         query,
         budget,

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -5,7 +5,17 @@ import pytest
 
 import server.discover as discover
 from crawler.frontier import Candidate
+from seed_loader.sources import SeedSource
 from server.discover import DiscoveryEngine, LLMReranker, extract_links, score_candidate
+
+
+@pytest.fixture(autouse=True)
+def stub_frontier_db(monkeypatch):
+    class _DummyDB:
+        def domain_value_map(self):
+            return {}
+
+    monkeypatch.setattr("crawler.frontier.get_db", lambda: _DummyDB())
 
 
 def test_extract_links_handles_relative_urls():
@@ -42,16 +52,22 @@ class StubAuthority:
         return self.scores.get(host, 0.0)
 
 
-class StubSeed:
-    def __init__(self, url: str, source: str = "seed") -> None:
-        self.url = url
-        self.source = source
-        self.tags: set[str] = set()
-
-
 def test_discovery_engine_merges_sources(monkeypatch):
-    def fake_registry(_: Iterable[str] | None) -> list[StubSeed]:
-        return [StubSeed("https://docs.alpha.dev"), StubSeed("https://beta.dev")]
+    def fake_registry(_: Iterable[str] | None) -> list[SeedSource]:
+        return [
+            SeedSource(
+                url="https://docs.alpha.dev",
+                source="registry:alpha",
+                tags={"registry"},
+                metadata={"trust": "high"},
+            ),
+            SeedSource(
+                url="https://beta.dev",
+                source="registry:beta",
+                tags={"registry"},
+                metadata={"trust": "medium"},
+            ),
+        ]
 
     learned = [
         {"domain": "gamma.dev", "score": 1.2, "url": "https://gamma.dev/docs"},
@@ -76,6 +92,60 @@ def test_discovery_engine_merges_sources(monkeypatch):
     assert any(url.startswith("https://docs.alpha.dev") for url in urls)
     assert any("gamma.dev" in url for url in urls)
     assert all(candidate.score is not None for candidate in frontier)
+
+
+def test_registry_trust_and_extras_affect_scores(monkeypatch):
+    registry = [
+        SeedSource(
+            url="https://alpha.dev/docs",
+            source="registry:alpha",
+            tags={"registry"},
+            metadata={
+                "trust": "high",
+                "boost": 1.3,
+                "value_prior": 2.5,
+                "freshness": 0.9,
+                "authority": 0.7,
+            },
+        ),
+        SeedSource(
+            url="https://beta.dev/docs",
+            source="registry:beta",
+            tags={"registry"},
+            metadata={"trust": "low"},
+        ),
+    ]
+
+    def fake_registry(_: Iterable[str] | None) -> list[SeedSource]:
+        return registry
+
+    engine = DiscoveryEngine(
+        registry_loader=fake_registry,
+        learned_loader=lambda: [],
+        authority_factory=lambda: StubAuthority({"alpha.dev": 0.4, "beta.dev": 0.1}),
+        per_host_cap=4,
+        politeness_delay=0.0,
+    )
+
+    captured: dict[str, list] = {}
+
+    def fake_frontier(query, *, discovery_hints, **kwargs):  # type: ignore[override]
+        captured["hints"] = list(discovery_hints)
+        return [
+            Candidate(url=hit.url, source=hit.source, weight=hit.score or 0.0, score=hit.score)
+            for hit in discovery_hints
+        ]
+
+    monkeypatch.setattr("crawler.frontier.build_frontier", fake_frontier)
+
+    engine.discover("alpha beta", limit=6, use_llm=False)
+
+    hints = {hit.url: hit for hit in captured["hints"]}
+    assert hints["https://alpha.dev/docs"].boost > hints["https://beta.dev/docs"].boost
+    assert hints["https://alpha.dev/docs"].value_prior == pytest.approx(2.5)
+    assert hints["https://alpha.dev/docs"].freshness == pytest.approx(0.9)
+    assert hints["https://alpha.dev/docs"].authority == pytest.approx(0.7)
+    assert (hints["https://alpha.dev/docs"].score or 0.0) > (hints["https://beta.dev/docs"].score or 0.0)
 
 
 def test_llm_reranker_orders_candidates(monkeypatch):
@@ -104,3 +174,38 @@ def test_llm_reranker_orders_candidates(monkeypatch):
     ranked = reranker("query", candidates)
     assert ranked[0].url == "https://b.dev"
     assert calls["url"].endswith("/api/generate")
+
+
+def test_get_seed_candidates_uses_registry(monkeypatch, tmp_path):
+    from backend.app.config import AppConfig
+    from backend.app.jobs import focused_crawl
+
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(discover, "CURATED_VALUES_PATH", tmp_path / "seeds" / "curated_seeds.jsonl", raising=False)
+    monkeypatch.setattr("rank.authority.DEFAULT_AUTHORITY_PATH", tmp_path / "authority.json", raising=False)
+
+    config = AppConfig.from_env()
+
+    captured: dict[str, list] = {}
+
+    def fake_frontier(query, *, discovery_hints, **kwargs):  # type: ignore[override]
+        captured["hints"] = list(discovery_hints)
+        return [
+            Candidate(url=hit.url, source=hit.source, weight=hit.score or 0.0, score=hit.score)
+            for hit in discovery_hints
+        ]
+
+    monkeypatch.setattr("crawler.frontier.build_frontier", fake_frontier)
+
+    seeds = focused_crawl._get_seed_candidates(
+        "python",
+        budget=5,
+        use_llm=False,
+        model=None,
+        config=config,
+    )
+
+    assert seeds
+    assert all(candidate.source != "fallback" for candidate in seeds)
+    assert any("docs.python.org" in candidate.url for candidate in seeds)
+    assert any(hit.source.startswith("registry:") for hit in captured.get("hints", []))


### PR DESCRIPTION
## Summary
- load the curated seed registry via `server.seeds_loader` and carry trust/extras into discovery scoring
- expose a registry-backed frontier fallback for `_get_seed_candidates` and rely on it before generic .com/.io fallbacks
- relocate heavyweight imports to runtime to break circular imports and extend discovery regression coverage

## Testing
- pytest tests/test_discover.py

------
https://chatgpt.com/codex/tasks/task_e_68d177188f708321bc05c9896dc4e914