### PR TITLE
Integrate discovery engine into cold-start indexing

### DIFF
--- a/engine/indexing/coldstart.py
+++ b/engine/indexing/coldstart.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Callable, Sequence
+import logging
+from typing import TYPE_CHECKING, Callable, Sequence
+
+from crawler.frontier import Candidate
 
 from ..data.store import VectorStore
-from ..search.provider import seed_urls_for_query
 from .chunk import TokenChunker
 from .crawl import CrawlClient, CrawlError
 from .embed import OllamaEmbedder
 
-SeedProvider = Callable[[str, int], Sequence[str]]
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from server.discover import DiscoveryEngine
+    from server.learned_web_db import LearnedWebDB
+
+CandidateProvider = Callable[[str, int, bool, str | None], Sequence[Candidate]]
 LLMSeedProvider = Callable[[str, int, str | None], Sequence[str]]
+
+LOGGER = logging.getLogger(__name__)
 
 
 class ColdStartIndexer:
@@ -23,7 +31,9 @@ class ColdStartIndexer:
         crawler: CrawlClient,
         chunker: TokenChunker,
         embedder: OllamaEmbedder,
-        seed_provider: SeedProvider = seed_urls_for_query,
+        discovery_engine: DiscoveryEngine | None = None,
+        learned_db: LearnedWebDB | None = None,
+        candidate_provider: CandidateProvider | None = None,
         llm_seed_provider: LLMSeedProvider | None = None,
         max_pages: int = 5,
     ) -> None:
@@ -31,30 +41,36 @@ class ColdStartIndexer:
         self._crawler = crawler
         self._chunker = chunker
         self._embedder = embedder
-        self._seed_provider = seed_provider
+        self._discovery_engine = discovery_engine
+        self._learned_db = learned_db
+        self._candidate_provider = candidate_provider
         self._llm_seed_provider = llm_seed_provider
         self._max_pages = max_pages
 
     def build_index(
         self, query: str, *, use_llm: bool = False, llm_model: str | None = None
     ) -> int:
-        base_urls = list(self._seed_provider(query, self._max_pages) or [])
-        llm_urls: list[str] = []
-        if use_llm and self._llm_seed_provider is not None:
-            llm_urls = [
-                url
-                for url in self._llm_seed_provider(query, self._max_pages, llm_model)
-                if isinstance(url, str) and url
-            ]
-        combined: list[str] = []
-        for url in llm_urls + base_urls:
-            if url and url not in combined:
-                combined.append(url)
-        urls = combined or base_urls
+        candidates = list(
+            (self._candidate_provider or self._discover_candidates)(
+                query, self._max_pages, use_llm, llm_model
+            )
+            or []
+        )
+        if not candidates:
+            return 0
+
         indexed = 0
-        for url in urls:
+        seen: set[str] = set()
+        for candidate in candidates:
             if indexed >= self._max_pages:
                 break
+            url = getattr(candidate, "url", "")
+            if not isinstance(url, str) or not url:
+                continue
+            if url in seen:
+                continue
+            seen.add(url)
+            self._persist_discovery(query, candidate)
             try:
                 result = self._crawler.fetch(url)
             except CrawlError:
@@ -79,6 +95,84 @@ class ColdStartIndexer:
             )
             indexed += 1
         return indexed
+
+    # ------------------------------------------------------------------
+    # Discovery helpers
+    # ------------------------------------------------------------------
+    def _ensure_discovery_engine(self) -> DiscoveryEngine:
+        if self._discovery_engine is None:
+            from server.discover import DiscoveryEngine as _DiscoveryEngine  # local import
+
+            self._discovery_engine = _DiscoveryEngine()
+        return self._discovery_engine
+
+    def _ensure_learned_db(self) -> LearnedWebDB | None:
+        if self._learned_db is None:
+            try:
+                from server.learned_web_db import get_db as _get_db  # local import
+
+                self._learned_db = _get_db()
+            except Exception:  # pragma: no cover - defensive
+                LOGGER.debug("failed to initialize learned web db", exc_info=True)
+                self._learned_db = None
+        return self._learned_db
+
+    def _discover_candidates(
+        self, query: str, limit: int, use_llm: bool, llm_model: str | None
+    ) -> Sequence[Candidate]:
+        llm_urls: list[str] = []
+        if use_llm and self._llm_seed_provider is not None:
+            for raw in self._llm_seed_provider(query, limit, llm_model):
+                if isinstance(raw, str):
+                    candidate = raw.strip()
+                    if candidate and candidate not in llm_urls:
+                        llm_urls.append(candidate)
+
+        engine = self._ensure_discovery_engine()
+        frontier = list(
+            engine.discover(
+                query,
+                limit=max(1, int(limit)),
+                extra_seeds=llm_urls,
+                use_llm=use_llm,
+                model=llm_model,
+            )
+        )
+        if frontier:
+            return frontier
+        return engine.registry_frontier(
+            query,
+            limit=max(1, int(limit)),
+            use_llm=use_llm,
+            model=llm_model,
+        )
+
+    def _persist_discovery(self, query: str, candidate: Candidate) -> None:
+        db = self._ensure_learned_db()
+        if db is None:
+            return
+        url = getattr(candidate, "url", "")
+        if not isinstance(url, str) or not url:
+            return
+        score_value = getattr(candidate, "score", None)
+        if score_value is None:
+            score_value = getattr(candidate, "weight", 0.0)
+        try:
+            score = float(score_value)
+        except (TypeError, ValueError):
+            score = 0.0
+        source = getattr(candidate, "source", None)
+        reason = f"coldstart:{source or 'seed'}"
+        try:
+            db.record_discovery(
+                query,
+                url,
+                reason=reason,
+                score=score,
+                source=source,
+            )
+        except Exception:  # pragma: no cover - defensive logging only
+            LOGGER.debug("failed to record discovery for url=%s", url, exc_info=True)
 
 
 __all__ = ["ColdStartIndexer"]

--- a/tests/engine/test_coldstart.py
+++ b/tests/engine/test_coldstart.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import List
+from crawler.frontier import Candidate
 
 from engine.indexing.coldstart import ColdStartIndexer
 from engine.indexing.crawl import CrawlResult
@@ -9,7 +7,7 @@ from engine.indexing.chunk import Chunk
 
 class StubStore:
     def __init__(self) -> None:
-        self.upserts: List[str] = []
+        self.upserts: list[str] = []
 
     def needs_update(self, url: str, etag: str | None, content_hash: str) -> bool:
         return True
@@ -20,7 +18,7 @@ class StubStore:
 
 class StubCrawler:
     def __init__(self) -> None:
-        self.visited: List[str] = []
+        self.visited: list[str] = []
         self.counter = 0
 
     def fetch(self, url: str) -> CrawlResult | None:
@@ -48,65 +46,121 @@ class StubEmbedder:
         return [[0.1] * 1 for _ in texts]
 
 
-def test_build_index_uses_llm_seeds_when_enabled():
+class StubLearnedDB:
+    def __init__(self) -> None:
+        self.records: list[dict[str, object]] = []
+
+    def record_discovery(self, query: str, url: str, *, reason: str, score: float, source=None, **kwargs):  # noqa: D401
+        self.records.append(
+            {
+                "query": query,
+                "url": url,
+                "reason": reason,
+                "score": score,
+                "source": source,
+            }
+        )
+        return 1, True
+
+
+def test_build_index_uses_candidate_provider_and_records_discoveries():
     store = StubStore()
     crawler = StubCrawler()
     chunker = StubChunker()
     embedder = StubEmbedder()
+    learned_db = StubLearnedDB()
 
-    def base_seeds(query: str, limit: int):
-        return ["https://base.example"]
+    captured: dict[str, tuple] = {}
 
-    captured = {}
-
-    def llm_seeds(query: str, limit: int, model: str | None):
-        captured["args"] = (query, limit, model)
-        return ["https://llm.example", "https://base.example"]
+    def candidate_provider(query: str, limit: int, use_llm: bool, model: str | None):
+        captured["args"] = (query, limit, use_llm, model)
+        return [
+            Candidate(url="https://alpha.example/docs", source="registry", weight=1.5, score=1.5),
+            Candidate(url="https://beta.example/blog", source="learned", weight=0.9, score=0.9),
+        ]
 
     indexer = ColdStartIndexer(
         store=store,
         crawler=crawler,
         chunker=chunker,
         embedder=embedder,
-        seed_provider=base_seeds,
-        llm_seed_provider=llm_seeds,
+        learned_db=learned_db,
+        candidate_provider=candidate_provider,
+        llm_seed_provider=None,
         max_pages=2,
     )
 
-    indexed = indexer.build_index("sample query", use_llm=True, llm_model="my-llm")
+    indexed = indexer.build_index("sample query", use_llm=True, llm_model="ollama")
 
     assert indexed == 2
-    assert crawler.visited == ["https://llm.example", "https://base.example"]
-    assert captured["args"] == ("sample query", 2, "my-llm")
+    assert crawler.visited == [
+        "https://alpha.example/docs",
+        "https://beta.example/blog",
+    ]
+    assert store.upserts == crawler.visited
+    assert captured["args"] == ("sample query", 2, True, "ollama")
+    assert [record["url"] for record in learned_db.records] == crawler.visited
+    assert all(record["reason"].startswith("coldstart:") for record in learned_db.records)
 
 
-def test_build_index_skips_llm_when_disabled():
+def test_default_discovery_helper_calls_discover_and_registry():
     store = StubStore()
     crawler = StubCrawler()
     chunker = StubChunker()
     embedder = StubEmbedder()
+    learned_db = StubLearnedDB()
 
-    def base_seeds(query: str, limit: int):
-        return ["https://base-only.example"]
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.calls: list[tuple] = []
 
-    llm_calls: List[tuple] = []
+        def discover(self, query, *, limit, extra_seeds, use_llm, model):
+            self.calls.append(("discover", query, limit, tuple(extra_seeds), use_llm, model))
+            return []
 
-    def llm_seeds(query: str, limit: int, model: str | None):
-        llm_calls.append((query, limit, model))
-        return ["https://llm.example"]
+        def registry_frontier(self, query, *, limit, use_llm, model):
+            self.calls.append(("registry", query, limit, use_llm, model))
+            return [
+                Candidate(
+                    url="https://docs.gamma.dev",
+                    source="registry",
+                    weight=1.0,
+                    score=1.2,
+                )
+            ]
+
+    engine = FakeEngine()
+    llm_calls: dict[str, tuple] = {}
+
+    def llm_seed_provider(query: str, limit: int, model: str | None):
+        llm_calls["args"] = (query, limit, model)
+        return ["https://planner.example/path", "https://planner.example/path"]
 
     indexer = ColdStartIndexer(
         store=store,
         crawler=crawler,
         chunker=chunker,
         embedder=embedder,
-        seed_provider=base_seeds,
-        llm_seed_provider=llm_seeds,
+        discovery_engine=engine,
+        learned_db=learned_db,
+        llm_seed_provider=llm_seed_provider,
         max_pages=1,
     )
 
-    indexed = indexer.build_index("another query", use_llm=False, llm_model="ignored")
+    indexed = indexer.build_index("gamma docs", use_llm=True, llm_model="llama")
 
     assert indexed == 1
-    assert crawler.visited == ["https://base-only.example"]
-    assert llm_calls == []
+    assert crawler.visited == ["https://docs.gamma.dev"]
+    assert store.upserts == ["https://docs.gamma.dev"]
+    assert llm_calls["args"] == ("gamma docs", 1, "llama")
+    assert engine.calls[0] == (
+        "discover",
+        "gamma docs",
+        1,
+        ("https://planner.example/path",),
+        True,
+        "llama",
+    )
+    assert engine.calls[1][0] == "registry"
+    assert learned_db.records and learned_db.records[0]["url"] == "https://docs.gamma.dev"
+    assert learned_db.records[0]["reason"] == "coldstart:registry"


### PR DESCRIPTION
## Summary
- replace the legacy Wikipedia seed helper with DiscoveryEngine-backed discovery in the cold-start indexer
- persist discovered candidates into the learned web database while crawling and allow LLM seed planning to inform discovery
- add focused unit coverage for the new discovery flow and document the revised bootstrap pipeline in the README

## Testing
- pytest tests/engine/test_coldstart.py

------
https://chatgpt.com/codex/tasks/task_e_68d17cba19348321be18fa18310ff001