### PR TITLE
Add sitemap-hunter seed entry

### DIFF
--- a/seeds/registry.yaml
+++ b/seeds/registry.yaml
@@ -39,3 +39,9 @@ sources:
       - https://data.europa.eu/en
       - https://www.data.gov.uk/
     trust: high
+  - id: sitemap-hunter
+    kind: crawler
+    strategy: sitemap
+    entrypoints:
+      - https://example.com/robots.txt
+    trust: medium


### PR DESCRIPTION
## Summary
- add a concrete entrypoint for the sitemap-hunter seed registry entry
- keep the sitemap-hunter record enabled so the loader accepts the registry

## Testing
- pytest tests/test_server_seeds_loader.py::test_load_seed_registry_normalizes

------
https://chatgpt.com/codex/tasks/task_e_68d2163fc7ec83218158b793d61a24ae