### PR TITLE
Add planner agent with tool dispatch and Ollama JSON wrapper

### DIFF
--- a/backend/app/jobs/research.py
+++ b/backend/app/jobs/research.py
@@ -11,6 +11,9 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from ..config import AppConfig
+from .focused_crawl import run_focused_crawl  # re-exported for monkeypatching
+
+
 def _ollama_request(url: str, model: Optional[str], system: str, prompt: str) -> str:
     payload = {
         "messages": [

--- a/server/agent.py
+++ b/server/agent.py
@@ -1,0 +1,164 @@
+"""Planner agent orchestrating tool calls to satisfy research queries."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from .llm import OllamaJSONClient
+from .tools import ToolDispatcher
+
+LOGGER = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = (
+    "You are the autonomous planner for a self-hosted search stack. "
+    "Always respond with a single JSON object. "
+    "When you need information use {\"type\": \"tool\", \"tool\": <name>, \"params\": {...}}. "
+    "When you are ready to answer return {\"type\": \"final\", \"answer\": <summary>, \"sources\": []}. "
+    "Do not include commentary outside the JSON object."
+)
+
+FEW_SHOT_MESSAGES: Sequence[Mapping[str, str]] = (
+    {
+        "role": "user",
+        "content": json.dumps(
+            {
+                "type": "query",
+                "query": "Find recent docs about crawling ethics",
+            }
+        ),
+    },
+    {
+        "role": "assistant",
+        "content": json.dumps(
+            {
+                "type": "tool",
+                "tool": "index.search",
+                "params": {"query": "crawling ethics", "k": 3},
+            }
+        ),
+    },
+    {
+        "role": "tool",
+        "name": "index.search",
+        "content": json.dumps(
+            {
+                "ok": True,
+                "tool": "index.search",
+                "result": {"results": []},
+            }
+        ),
+    },
+    {
+        "role": "assistant",
+        "content": json.dumps(
+            {
+                "type": "final",
+                "answer": "No indexed documents found. Recommend triggering a crawl.",
+                "sources": [],
+            }
+        ),
+    },
+)
+
+
+@dataclass
+class PlannerAgent:
+    llm: OllamaJSONClient
+    tools: ToolDispatcher
+    default_model: str | None = None
+    max_iterations: int = 6
+    logger: logging.Logger = field(default=LOGGER)
+
+    def run(
+        self,
+        query: str,
+        *,
+        context: Mapping[str, Any] | None = None,
+        model: str | None = None,
+    ) -> Mapping[str, Any]:
+        self.logger.info("planner starting query=%s", query)
+        messages = list(self._bootstrap_messages(query, context))
+        steps: list[dict[str, Any]] = []
+        for iteration in range(1, self.max_iterations + 1):
+            self.logger.debug("planner iteration=%s", iteration)
+            response = self.llm.chat_json(messages, model=model or self.default_model)
+            steps.append({"iteration": iteration, "response": response})
+            self.logger.info("planner step %s response=%s", iteration, json.dumps(response))
+            messages.append({"role": "assistant", "content": json.dumps(response)})
+            message_type = response.get("type")
+            if message_type == "tool":
+                tool_name = response.get("tool")
+                params = response.get("params") if isinstance(response.get("params"), Mapping) else {}
+                tool_result = self.tools.execute(tool_name, params)
+                steps[-1]["tool"] = tool_result
+                self.logger.info(
+                    "planner tool %s result=%s", tool_name, json.dumps(tool_result)
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "name": str(tool_name),
+                        "content": json.dumps(tool_result),
+                    }
+                )
+                continue
+            if message_type == "final":
+                final_payload = self._normalize_final(response, steps)
+                self.logger.info("planner completed query=%s", query)
+                return final_payload
+            error = {
+                "ok": False,
+                "tool": "planner",
+                "error": "invalid response type",
+                "received": response,
+            }
+            steps[-1]["error"] = error
+            self.logger.warning("planner invalid response -> %s", json.dumps(error))
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": "planner",
+                    "content": json.dumps(error),
+                }
+            )
+        self.logger.warning("planner hit iteration limit for query=%s", query)
+        return {
+            "type": "final",
+            "answer": "",
+            "sources": [],
+            "error": "iteration limit reached",
+            "steps": steps,
+        }
+
+    def _bootstrap_messages(
+        self, query: str, context: Mapping[str, Any] | None
+    ) -> Iterable[Mapping[str, Any]]:
+        yield {"role": "system", "content": SYSTEM_PROMPT}
+        yield from FEW_SHOT_MESSAGES
+        payload = {
+            "type": "query",
+            "query": query,
+            "context": dict(context or {}),
+        }
+        yield {"role": "user", "content": json.dumps(payload)}
+
+    @staticmethod
+    def _normalize_final(
+        payload: Mapping[str, Any], steps: Sequence[Mapping[str, Any]]
+    ) -> Mapping[str, Any]:
+        final = {
+            "type": "final",
+            "answer": payload.get("answer", ""),
+            "sources": payload.get("sources", []),
+            "context": payload.get("context", {}),
+            "steps": list(steps),
+        }
+        if "error" in payload:
+            final["error"] = payload["error"]
+        return final
+
+
+__all__ = ["PlannerAgent", "SYSTEM_PROMPT", "FEW_SHOT_MESSAGES"]

--- a/server/llm.py
+++ b/server/llm.py
@@ -1,0 +1,195 @@
+"""JSON-focused Ollama chat helper used by the planner agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LLMError(RuntimeError):
+    """Raised when the planner LLM cannot complete a request."""
+
+
+def _env_base_url() -> str:
+    for key in ("OLLAMA_JSON_HOST", "OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST"):
+        candidate = (os.getenv(key) or "").strip()
+        if candidate:
+            return candidate.rstrip("/")
+    return "http://127.0.0.1:11434"
+
+
+def _env_model() -> str:
+    for key in ("OLLAMA_JSON_MODEL", "OLLAMA_MODEL"):
+        candidate = (os.getenv(key) or "").strip()
+        if candidate:
+            return candidate
+    return "llama3.1:8b-instruct"
+
+
+@dataclass(slots=True)
+class ChatMessage:
+    role: str
+    content: str
+
+
+class OllamaJSONClient:
+    """Small wrapper forcing the Ollama chat endpoint to yield JSON payloads."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        default_model: str | None = None,
+        timeout: float = 60.0,
+        session: requests.Session | None = None,
+    ) -> None:
+        self.base_url = (base_url or _env_base_url()).rstrip("/")
+        self.default_model = default_model or _env_model()
+        self.timeout = timeout
+        self._session = session or requests.Session()
+        self._model_cache: tuple[list[str], float] | None = None
+
+    # ------------------------------------------------------------------
+    # Model helpers
+    # ------------------------------------------------------------------
+    def list_models(self, *, refresh: bool = False) -> list[str]:
+        if not refresh and self._model_cache:
+            cached, expiry = self._model_cache
+            if time.monotonic() < expiry:
+                return list(cached)
+        try:
+            response = self._session.get(
+                f"{self.base_url}/api/tags", timeout=self.timeout
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise LLMError(str(exc)) from exc
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise LLMError("Invalid JSON from Ollama tags endpoint") from exc
+        models: list[str] = []
+        for item in payload.get("models", []):
+            if isinstance(item, str):
+                name = item
+            elif isinstance(item, Mapping):
+                candidate = item.get("name")
+                name = candidate if isinstance(candidate, str) else None
+            else:
+                name = None
+            if name:
+                cleaned = name.strip()
+                if cleaned:
+                    models.append(cleaned)
+        self._model_cache = (models, time.monotonic() + 30.0)
+        return list(models)
+
+    def select_model(self, preferred: str | None = None) -> str:
+        candidates = [preferred, self.default_model]
+        try:
+            available = self.list_models()
+        except LLMError:
+            available = []
+        for candidate in candidates:
+            if not candidate:
+                continue
+            cleaned = candidate.strip()
+            if not cleaned:
+                continue
+            if not available or cleaned in available:
+                return cleaned
+        return candidates[-1] or _env_model()
+
+    # ------------------------------------------------------------------
+    # Chat completions
+    # ------------------------------------------------------------------
+    def chat_json(
+        self,
+        messages: Sequence[Mapping[str, str]] | Sequence[ChatMessage],
+        *,
+        model: str | None = None,
+        options: Mapping[str, object] | None = None,
+    ) -> Mapping[str, object]:
+        resolved_model = self.select_model(model)
+        payload = {
+            "model": resolved_model,
+            "messages": [
+                message.__dict__ if isinstance(message, ChatMessage) else dict(message)
+                for message in messages
+            ],
+            "stream": False,
+            "format": "json",
+        }
+        if options:
+            payload["options"] = dict(options)
+        LOGGER.debug("planner.llm calling model=%s", resolved_model)
+        try:
+            response = self._session.post(
+                f"{self.base_url}/api/chat", json=payload, timeout=self.timeout
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise LLMError(str(exc)) from exc
+        raw_content = self._extract_content(response)
+        try:
+            return self._parse_json(raw_content)
+        except ValueError as exc:
+            raise LLMError(f"Invalid JSON payload from model {resolved_model}") from exc
+
+    def _extract_content(self, response: requests.Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise LLMError("Non-JSON response from Ollama chat") from exc
+        message = payload.get("message") if isinstance(payload, Mapping) else None
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                return content
+        content = payload.get("response") if isinstance(payload, Mapping) else None
+        if isinstance(content, str) and content.strip():
+            return content
+        raise LLMError("Ollama chat response missing content")
+
+    # ------------------------------------------------------------------
+    # JSON coercion helpers
+    # ------------------------------------------------------------------
+    def _parse_json(self, text: str) -> Mapping[str, object]:
+        cleaned = self._strip_code_fence(text)
+        try:
+            return json.loads(cleaned)
+        except ValueError:
+            snippet = self._extract_json_block(cleaned)
+            return json.loads(snippet)
+
+    @staticmethod
+    def _strip_code_fence(text: str) -> str:
+        stripped = text.strip()
+        if stripped.startswith("```") and stripped.endswith("```"):
+            lines = stripped.splitlines()
+            if lines and lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].startswith("```"):
+                lines = lines[:-1]
+            stripped = "\n".join(lines)
+        return stripped.strip()
+
+    @staticmethod
+    def _extract_json_block(text: str) -> str:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise ValueError("No JSON object found")
+        candidate = text[start : end + 1]
+        return candidate
+
+
+__all__ = ["ChatMessage", "LLMError", "OllamaJSONClient"]

--- a/server/tools.py
+++ b/server/tools.py
@@ -1,0 +1,200 @@
+"""Tool adapters exposed to the planner agent."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from engine.data.store import RetrievedChunk, VectorStore
+from engine.indexing.chunk import TokenChunker
+from engine.indexing.crawl import CrawlClient, CrawlError
+from engine.indexing.embed import EmbeddingError, OllamaEmbedder
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ToolExecutionError(RuntimeError):
+    """Raised when a tool invocation cannot be completed."""
+
+
+@dataclass(slots=True)
+class IndexAPI:
+    store: VectorStore
+    embedder: OllamaEmbedder
+    chunker: TokenChunker
+    default_k: int = 5
+    similarity_threshold: float = 0.2
+
+    def search(
+        self,
+        *,
+        query: str,
+        k: int | None = None,
+        threshold: float | None = None,
+    ) -> MutableMapping[str, Any]:
+        clean_query = (query or "").strip()
+        if not clean_query:
+            return {"query": clean_query, "results": []}
+        limit = int(k) if k is not None else self.default_k
+        limit = max(1, limit)
+        try:
+            embedding = self.embedder.embed_query(clean_query)
+        except EmbeddingError as exc:
+            raise ToolExecutionError(str(exc)) from exc
+        use_threshold = threshold if threshold is not None else self.similarity_threshold
+        hits = self.store.query(embedding, limit, use_threshold)
+        results = [self._format_chunk(chunk) for chunk in hits]
+        return {
+            "query": clean_query,
+            "results": results,
+            "embedding_dimensions": len(embedding),
+        }
+
+    def upsert(
+        self,
+        *,
+        url: str,
+        text: str,
+        title: str | None = None,
+        etag: str | None = None,
+        content_hash: str | None = None,
+    ) -> MutableMapping[str, Any]:
+        clean_url = (url or "").strip()
+        if not clean_url:
+            raise ToolExecutionError("url must be provided")
+        body = (text or "").strip()
+        if not body:
+            raise ToolExecutionError("text must be provided")
+        digest = content_hash or hashlib.sha256(body.encode("utf-8")).hexdigest()
+        if not self.store.needs_update(clean_url, etag, digest):
+            LOGGER.debug("index.upsert skipped %s (unchanged)", clean_url)
+            return {"url": clean_url, "skipped": True}
+        chunks = self.chunker.chunk_text(body)
+        if not chunks:
+            raise ToolExecutionError("unable to chunk document")
+        try:
+            embeddings = self.embedder.embed_documents([chunk.text for chunk in chunks])
+        except EmbeddingError as exc:
+            raise ToolExecutionError(str(exc)) from exc
+        if len(embeddings) != len(chunks):
+            raise ToolExecutionError("embedding count mismatch")
+        self.store.upsert(
+            url=clean_url,
+            title=title or clean_url,
+            etag=etag,
+            content_hash=digest,
+            chunks=chunks,
+            embeddings=embeddings,
+        )
+        return {
+            "url": clean_url,
+            "chunks": len(chunks),
+            "embedding_dimensions": len(embeddings[0]) if embeddings else 0,
+            "skipped": False,
+        }
+
+    @staticmethod
+    def _format_chunk(chunk: RetrievedChunk) -> dict[str, Any]:
+        return {
+            "text": chunk.text,
+            "title": chunk.title,
+            "url": chunk.url,
+            "similarity": chunk.similarity,
+        }
+
+
+@dataclass(slots=True)
+class CrawlerAPI:
+    crawler: CrawlClient
+
+    def fetch(self, *, url: str) -> MutableMapping[str, Any]:
+        clean_url = (url or "").strip()
+        if not clean_url:
+            raise ToolExecutionError("url must be provided")
+        try:
+            result = self.crawler.fetch(clean_url)
+        except CrawlError as exc:
+            raise ToolExecutionError(str(exc)) from exc
+        if result is None:
+            raise ToolExecutionError("fetch returned no content")
+        return {
+            "url": result.url,
+            "title": result.title,
+            "text": result.text,
+            "etag": result.etag,
+            "content_hash": result.content_hash,
+            "status_code": result.status_code,
+        }
+
+
+@dataclass(slots=True)
+class EmbedAPI:
+    embedder: OllamaEmbedder
+
+    def embed_query(self, *, text: str) -> MutableMapping[str, Any]:
+        body = (text or "").strip()
+        if not body:
+            raise ToolExecutionError("text must be provided")
+        try:
+            vector = self.embedder.embed_query(body)
+        except EmbeddingError as exc:
+            raise ToolExecutionError(str(exc)) from exc
+        return {"embedding": vector, "dimensions": len(vector), "model": self.embedder.model}
+
+    def embed_documents(self, *, texts: Sequence[str]) -> MutableMapping[str, Any]:
+        sanitized = [str(text) for text in texts if str(text).strip()]
+        if not sanitized:
+            raise ToolExecutionError("texts must contain at least one entry")
+        try:
+            vectors = self.embedder.embed_documents(sanitized)
+        except EmbeddingError as exc:
+            raise ToolExecutionError(str(exc)) from exc
+        return {
+            "embeddings": vectors,
+            "count": len(vectors),
+            "model": self.embedder.model,
+        }
+
+
+@dataclass
+class ToolDispatcher:
+    index_api: IndexAPI
+    crawler_api: CrawlerAPI
+    embed_api: EmbedAPI
+    _registry: dict[str, Any] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._registry = {
+            "index.search": self.index_api.search,
+            "index.upsert": self.index_api.upsert,
+            "crawl.fetch": self.crawler_api.fetch,
+            "embed.query": self.embed_api.embed_query,
+            "embed.documents": self.embed_api.embed_documents,
+        }
+
+    def execute(self, tool: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        handler = self._registry.get(tool)
+        if handler is None:
+            LOGGER.warning("planner requested unknown tool %s", tool)
+            return {"ok": False, "tool": tool, "error": f"unknown tool: {tool}"}
+        payload = params or {}
+        try:
+            result = handler(**{str(k): v for k, v in payload.items()})
+        except ToolExecutionError as exc:
+            LOGGER.info("tool %s failed: %s", tool, exc)
+            return {"ok": False, "tool": tool, "error": str(exc)}
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.exception("unexpected error running tool %s", tool)
+            return {"ok": False, "tool": tool, "error": str(exc)}
+        return {"ok": True, "tool": tool, "result": result}
+
+
+__all__ = [
+    "ToolExecutionError",
+    "IndexAPI",
+    "CrawlerAPI",
+    "EmbedAPI",
+    "ToolDispatcher",
+]

--- a/tests/server/test_agent.py
+++ b/tests/server/test_agent.py
@@ -1,0 +1,159 @@
+"""Tests for the planner agent stack (LLM wrapper + tool dispatcher)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from engine.data.store import RetrievedChunk
+from engine.indexing.chunk import TokenChunker
+from engine.indexing.crawl import CrawlResult, CrawlError
+
+from server.agent import PlannerAgent
+from server.llm import OllamaJSONClient
+from server.tools import CrawlerAPI, EmbedAPI, IndexAPI, ToolDispatcher
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError("boom")
+
+    def json(self):  # pragma: no cover - trivial
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, post_payload):
+        self.post_payload = post_payload
+        self.post_calls = []
+
+    def get(self, url, timeout):  # pragma: no cover - defensive
+        return FakeResponse({"models": [{"name": "llama"}]})
+
+    def post(self, url, json, timeout):
+        self.post_calls.append((url, json))
+        return FakeResponse(self.post_payload)
+
+
+def test_json_client_parses_code_fence():
+    payload = {
+        "message": {
+            "content": "```json\n{\"type\":\"final\",\"answer\":\"ok\",\"sources\":[]}\n```"
+        }
+    }
+    client = OllamaJSONClient(base_url="http://fake", default_model="llama", session=FakeSession(payload))
+    result = client.chat_json([{"role": "user", "content": "hi"}])
+    assert result["type"] == "final"
+    assert result["answer"] == "ok"
+
+
+class FakeVectorStore:
+    def __init__(self):
+        self.upserts = []
+        self.checked = []
+
+    def query(self, vector, k, threshold):
+        return [RetrievedChunk(text="chunk", title="Doc", url="https://example", similarity=0.9)]
+
+    def needs_update(self, url, etag, content_hash):
+        self.checked.append((url, content_hash))
+        return True
+
+    def upsert(self, url, title, etag, content_hash, chunks, embeddings):
+        self.upserts.append((url, title, etag, content_hash, chunks, embeddings))
+
+
+class FakeEmbedder:
+    model = "fake-embed"
+
+    def embed_query(self, text: str):
+        return [1.0, 0.0, 0.5]
+
+    def embed_documents(self, texts):
+        return [[float(index + 1)] for index, _ in enumerate(texts)]
+
+
+@dataclass
+class FakeCrawler:
+    def fetch(self, url: str):
+        if url == "fail":
+            raise CrawlError("boom")
+        if url == "empty":
+            return None
+        return CrawlResult(
+            url=url,
+            status_code=200,
+            html="<html></html>",
+            text="hello world",
+            title="Example",
+            etag="etag",
+            last_modified=None,
+            content_hash="hash",
+        )
+
+
+@pytest.fixture()
+def dispatcher():
+    vector_store = FakeVectorStore()
+    embedder = FakeEmbedder()
+    chunker = TokenChunker(chunk_size=20, overlap=0)
+    index_api = IndexAPI(vector_store, embedder, chunker, default_k=3, similarity_threshold=0.2)
+    crawler_api = CrawlerAPI(FakeCrawler())
+    embed_api = EmbedAPI(embedder)
+    return ToolDispatcher(index_api=index_api, crawler_api=crawler_api, embed_api=embed_api)
+
+
+def test_tool_dispatcher_handles_success_and_failure(dispatcher):
+    search = dispatcher.execute("index.search", {"query": "hello"})
+    assert search["ok"]
+    assert search["result"]["results"]
+
+    upsert = dispatcher.execute("index.upsert", {"url": "https://example", "text": "hello world"})
+    assert upsert["ok"]
+    assert upsert["result"]["chunks"] == 1
+
+    failure = dispatcher.execute("crawl.fetch", {"url": "empty"})
+    assert not failure["ok"]
+    assert "error" in failure
+
+
+class FakeLLM:
+    def __init__(self):
+        self.calls = 0
+
+    def chat_json(self, messages, model=None):
+        self.calls += 1
+        if self.calls == 1:
+            return {"type": "tool", "tool": "index.search", "params": {"query": "widgets"}}
+        tool_messages = [m for m in messages if m.get("role") == "tool"]
+        assert tool_messages, "tool result should be returned to the model"
+        return {"type": "final", "answer": "done", "sources": ["https://example"]}
+
+
+def test_planner_agent_runs_tool_loop(dispatcher):
+    agent = PlannerAgent(llm=FakeLLM(), tools=dispatcher, max_iterations=3)
+    final = agent.run("Find widgets")
+    assert final["type"] == "final"
+    assert final["answer"] == "done"
+    assert final["steps"]
+
+
+class LoopLLM:
+    def chat_json(self, messages, model=None):
+        return {"type": "tool", "tool": "index.search", "params": {"query": "loop"}}
+
+
+def test_planner_agent_enforces_iteration_limit(dispatcher):
+    agent = PlannerAgent(llm=LoopLLM(), tools=dispatcher, max_iterations=2)
+    final = agent.run("Loop forever")
+    assert final["type"] == "final"
+    assert final.get("error") == "iteration limit reached"
+    assert len(final["steps"]) == 2


### PR DESCRIPTION
## Summary
- implement an Ollama JSON-only chat client with environment-driven model selection and relaxed parsing
- add index, embed, and crawl tool adapters plus a planner agent that iterates tool calls until a final answer
- expose the planner stack via the Flask app config and re-export the focused crawl helper for testing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d217a36c38832192dcc0bd426bda57