### PR TITLE
Add registry-backed discovery helpers and planner seeds tool

### DIFF
--- a/engine/discovery/__init__.py
+++ b/engine/discovery/__init__.py
@@ -1,0 +1,5 @@
+"""Discovery helpers orchestrating registry-backed strategies."""
+
+from .gather import RegistryCandidate, gather_from_registry
+
+__all__ = ["RegistryCandidate", "gather_from_registry"]

--- a/engine/discovery/gather.py
+++ b/engine/discovery/gather.py
@@ -1,0 +1,172 @@
+"""Registry loader that coordinates discovery strategies."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+from urllib.parse import urlparse
+
+from server.seeds_loader import SeedRegistryEntry, load_seed_registry
+
+from .strategies import STRATEGY_REGISTRY, StrategyCandidate
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class RegistryCandidate:
+    """Normalized candidate surfaced from the registry."""
+
+    url: str
+    score: float
+    source: str
+    strategy: str
+    entry_id: str
+    title: str | None = None
+    summary: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "url": self.url,
+            "score": self.score,
+            "source": self.source,
+            "strategy": self.strategy,
+            "entry_id": self.entry_id,
+        }
+        if self.title:
+            payload["title"] = self.title
+        if self.summary:
+            payload["summary"] = self.summary
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+def _sanitize_url(url: str) -> str | None:
+    candidate = (url or "").strip()
+    if not candidate:
+        return None
+    parsed = urlparse(candidate)
+    if not parsed.scheme:
+        if candidate.startswith("//"):
+            candidate = "https:" + candidate
+        else:
+            candidate = "https://" + candidate.lstrip("/")
+        parsed = urlparse(candidate)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "https"
+    path = parsed.path or "/"
+    sanitized = f"{scheme}://{parsed.netloc}{path}"
+    if parsed.query:
+        sanitized = f"{sanitized}?{parsed.query}"
+    return sanitized.rstrip("/")
+
+
+def _trust_multiplier(value: object) -> float:
+    if isinstance(value, (int, float)):
+        return max(0.1, float(value))
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if not text:
+            return 1.0
+        if text == "low":
+            return 0.85
+        if text == "medium":
+            return 1.0
+        if text == "high":
+            return 1.2
+        try:
+            return max(0.1, float(text))
+        except ValueError:
+            return 1.0
+    return 1.0
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _score_with_trust(raw_score: float, trust: object, extras: dict[str, object]) -> float:
+    base = float(raw_score) if raw_score is not None else 0.0
+    if base <= 0:
+        base = 0.05
+    multiplier = _trust_multiplier(trust)
+    boost = _coerce_float(extras.get("boost")) if isinstance(extras, dict) else None
+    if boost is not None and boost > 0:
+        multiplier *= boost
+    return base * multiplier
+
+
+def _collect_candidates(
+    *,
+    entry: SeedRegistryEntry,
+    query: str,
+    limit: int,
+) -> Iterable[StrategyCandidate]:
+    strategy = STRATEGY_REGISTRY.get(entry.strategy)
+    if strategy is None:
+        LOGGER.debug("unknown registry strategy '%s'", entry.strategy)
+        return []
+    try:
+        return strategy(entry, query, limit)
+    except Exception:  # pragma: no cover - defensive logging
+        LOGGER.debug("strategy %s failed for %s", entry.strategy, entry.id, exc_info=True)
+        return []
+
+
+def gather_from_registry(query: str, max_candidates: int = 10) -> List[RegistryCandidate]:
+    """Run configured registry strategies for ``query`` and dedupe results."""
+
+    clean_query = (query or "").strip()
+    if not clean_query:
+        return []
+    cap = max(1, int(max_candidates))
+    entries = load_seed_registry()
+    if not entries:
+        return []
+
+    deduped: Dict[str, RegistryCandidate] = {}
+    for entry in entries:
+        raw_candidates = _collect_candidates(entry=entry, query=clean_query, limit=cap)
+        if not raw_candidates:
+            continue
+        base_metadata = {"trust": entry.trust}
+        base_metadata.update(entry.extras)
+        for candidate in raw_candidates:
+            sanitized = _sanitize_url(candidate.url)
+            if not sanitized:
+                continue
+            score = _score_with_trust(candidate.score, entry.trust, entry.extras)
+            metadata = dict(base_metadata)
+            metadata.update(candidate.metadata)
+            result = RegistryCandidate(
+                url=sanitized,
+                score=score,
+                source=f"registry:{entry.id}",
+                strategy=entry.strategy,
+                entry_id=entry.id,
+                title=candidate.title,
+                summary=candidate.summary,
+                metadata=metadata,
+            )
+            existing = deduped.get(sanitized)
+            if existing is None or result.score > existing.score:
+                deduped[sanitized] = result
+    ordered = sorted(deduped.values(), key=lambda item: item.score, reverse=True)
+    return ordered[:cap]
+
+
+__all__ = ["RegistryCandidate", "gather_from_registry"]

--- a/engine/discovery/strategies.py
+++ b/engine/discovery/strategies.py
@@ -1,0 +1,247 @@
+"""Registry-backed discovery strategies for surfacing crawl seeds."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, Iterator, Sequence
+from urllib.parse import urljoin, urlparse
+from xml.etree import ElementTree
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from server.seeds_loader import SeedRegistryEntry
+
+DISCOVERY_USER_AGENT = os.getenv(
+    "DISCOVERY_USER_AGENT", "SelfHostedSearchBot/0.3 (+registry-discovery)"
+)
+FEED_TIMEOUT = float(os.getenv("DISCOVERY_FEED_TIMEOUT", "10"))
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(slots=True)
+class StrategyCandidate:
+    """Intermediate candidate returned by registry strategies."""
+
+    url: str
+    score: float = 0.0
+    title: str | None = None
+    summary: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+StrategyFn = Callable[["SeedRegistryEntry", str, int], Sequence[StrategyCandidate]]
+
+
+def _keyword_tokens(query: str) -> list[str]:
+    lowered = (query or "").lower()
+    tokens = _WORD_RE.findall(lowered)
+    return tokens
+
+
+def _strip_tag(tag: str) -> str:
+    if "}" in tag:
+        return tag.rsplit("}", 1)[-1].lower()
+    return tag.lower()
+
+
+def _resolve_url(candidate: str, base_url: str) -> str | None:
+    text = (candidate or "").strip()
+    if not text:
+        return None
+    if text.startswith("//"):
+        parsed = urlparse(base_url)
+        scheme = parsed.scheme or "https"
+        text = f"{scheme}:{text}"
+    if text.startswith(("http://", "https://")):
+        return text
+    return urljoin(base_url, text)
+
+
+def _extract_entry(
+    element: ElementTree.Element, base_url: str
+) -> tuple[str | None, str | None, str | None, dict[str, object]]:
+    title: str | None = None
+    summary_parts: list[str] = []
+    link: str | None = None
+    metadata: dict[str, object] = {}
+    for child in list(element):
+        name = _strip_tag(child.tag)
+        if name == "title":
+            text = " ".join(segment.strip() for segment in child.itertext() if segment.strip())
+            if text:
+                title = text
+        elif name == "link":
+            href = child.get("href") or " ".join(
+                segment.strip() for segment in child.itertext() if segment.strip()
+            )
+            resolved = _resolve_url(href, base_url)
+            if resolved:
+                link = resolved
+        elif name in {"description", "summary", "content"}:
+            text = " ".join(segment.strip() for segment in child.itertext() if segment.strip())
+            if text:
+                summary_parts.append(text)
+        elif name in {"id", "guid"}:
+            identifier = " ".join(
+                segment.strip() for segment in child.itertext() if segment.strip()
+            )
+            if identifier:
+                metadata.setdefault("entry_id", identifier)
+        elif name in {"updated", "published", "pubdate"}:
+            timestamp = " ".join(
+                segment.strip() for segment in child.itertext() if segment.strip()
+            )
+            if timestamp:
+                metadata.setdefault("published", timestamp)
+    if link is None:
+        href = element.attrib.get("href") or element.attrib.get("url")
+        resolved = _resolve_url(href, base_url) if href else None
+        if resolved:
+            link = resolved
+    summary = " ".join(summary_parts).strip() or None
+    return link, title, summary, metadata
+
+
+def _iter_feed_entries(xml_text: str, base_url: str) -> Iterator[tuple[str, str | None, str | None, dict[str, object]]]:
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        LOGGER.debug("invalid feed payload for %s", base_url)
+        return iter(())
+    items: list[ElementTree.Element] = []
+    for element in root.iter():
+        tag = _strip_tag(element.tag)
+        if tag in {"item", "entry"}:
+            items.append(element)
+    for element in items:
+        link, title, summary, metadata = _extract_entry(element, base_url)
+        if link:
+            yield link, title, summary, metadata
+
+
+def _score_entry(tokens: Sequence[str], title: str | None, summary: str | None) -> float:
+    if not tokens:
+        return 0.0
+    corpus = " ".join(part for part in (title, summary) if part).lower()
+    if not corpus:
+        return 0.0
+    hits = sum(1 for token in tokens if token in corpus)
+    if not hits:
+        return 0.0
+    return hits / len(tokens)
+
+
+def _root_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def rss_hub(entry: "SeedRegistryEntry", query: str, limit: int) -> list[StrategyCandidate]:
+    """Fetch RSS/Atom feeds and rank entries by keyword overlap."""
+
+    tokens = _keyword_tokens(query)
+    cap = max(1, int(limit))
+    candidates: list[StrategyCandidate] = []
+    seen: set[str] = set()
+    for feed_url in entry.entrypoints:
+        added = False
+        try:
+            response = requests.get(
+                feed_url,
+                headers={
+                    "User-Agent": DISCOVERY_USER_AGENT,
+                    "Accept": "application/rss+xml, application/atom+xml, application/xml;q=0.8",
+                },
+                timeout=(5, FEED_TIMEOUT),
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network guard
+            LOGGER.debug("rss_hub failed for %s: %s", feed_url, exc)
+            response_text = ""
+        else:
+            response_text = response.text
+        for link, title, summary, metadata in _iter_feed_entries(response_text, feed_url):
+            if len(candidates) >= cap:
+                break
+            if link in seen:
+                continue
+            seen.add(link)
+            score = _score_entry(tokens, title, summary)
+            if score <= 0:
+                score = 0.05
+            metadata = dict(metadata)
+            metadata.setdefault("feed", feed_url)
+            candidates.append(
+                StrategyCandidate(
+                    url=link,
+                    score=score,
+                    title=title,
+                    summary=summary,
+                    metadata=metadata,
+                )
+            )
+            added = True
+        if not added:
+            fallback = _root_url(feed_url)
+            if fallback and fallback not in seen and len(candidates) < cap:
+                seen.add(fallback)
+                candidates.append(
+                    StrategyCandidate(
+                        url=fallback,
+                        score=0.02,
+                        metadata={"feed": feed_url, "fallback": True},
+                    )
+                )
+        if len(candidates) >= cap:
+            break
+    return candidates[:cap]
+
+
+def html_extract_links(entry: "SeedRegistryEntry", query: str, limit: int) -> list[StrategyCandidate]:
+    """Placeholder for HTML link extraction strategy."""
+
+    LOGGER.debug("html_extract_links strategy not yet implemented for %s", entry.id)
+    return []
+
+
+def github_topics(entry: "SeedRegistryEntry", query: str, limit: int) -> list[StrategyCandidate]:
+    """Placeholder for GitHub topics strategy."""
+
+    LOGGER.debug("github_topics strategy not yet implemented for %s", entry.id)
+    return []
+
+
+def curated_list(entry: "SeedRegistryEntry", query: str, limit: int) -> list[StrategyCandidate]:
+    """Placeholder for curated list strategy."""
+
+    LOGGER.debug("curated_list strategy not yet implemented for %s", entry.id)
+    return []
+
+
+def sitemap_index(entry: "SeedRegistryEntry", query: str, limit: int) -> list[StrategyCandidate]:
+    """Placeholder for sitemap index discovery strategy."""
+
+    LOGGER.debug("sitemap_index strategy not yet implemented for %s", entry.id)
+    return []
+
+
+STRATEGY_REGISTRY: dict[str, StrategyFn] = {
+    "rss_hub": rss_hub,
+    "feed": rss_hub,  # backwards-compatible alias
+    "html_extract_links": html_extract_links,
+    "github_topics": github_topics,
+    "curated_list": curated_list,
+    "sitemap_index": sitemap_index,
+}
+
+
+__all__ = ["StrategyCandidate", "STRATEGY_REGISTRY", "rss_hub"]

--- a/tests/engine/test_discovery_gather.py
+++ b/tests/engine/test_discovery_gather.py
@@ -1,0 +1,75 @@
+"""Unit tests for registry discovery helpers."""
+
+from __future__ import annotations
+
+import requests
+
+from engine.discovery.gather import RegistryCandidate, gather_from_registry
+from server.seeds_loader import SeedRegistryEntry
+
+
+class FakeResponse:
+    def __init__(self, text: str, status_code: int = 200) -> None:
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+def test_gather_from_registry_uses_rss_strategy(monkeypatch):
+    entry = SeedRegistryEntry(
+        id="rss-test",
+        kind="feed",
+        strategy="rss_hub",
+        entrypoints=(
+            "https://example.com/feed.xml",
+            "https://fallback.example.net/rss",
+        ),
+        trust="high",
+        extras={"boost": 1.5},
+    )
+
+    feed_payload = """
+    <rss version="2.0">
+      <channel>
+        <title>Example Feed</title>
+        <item>
+          <title>Python Web Scraping Tips</title>
+          <link>https://example.com/python-scraping</link>
+          <description>Hands-on guide for web scraping.</description>
+        </item>
+        <item>
+          <title>Community Update</title>
+          <link>/community</link>
+          <description>News unrelated to scraping.</description>
+        </item>
+      </channel>
+    </rss>
+    """.strip()
+
+    def fake_get(url, headers, timeout):
+        if "example.com" in url:
+            return FakeResponse(feed_payload)
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(
+        "engine.discovery.gather.load_seed_registry", lambda: [entry]
+    )
+    monkeypatch.setattr("engine.discovery.strategies.requests.get", fake_get)
+
+    results = gather_from_registry("Python web scraping", max_candidates=5)
+    assert results, "expected registry candidates"
+    assert all(isinstance(item, RegistryCandidate) for item in results)
+
+    urls = [item.url for item in results]
+    assert "https://example.com/python-scraping" in urls
+    assert "https://example.com/community" in urls
+    assert "https://fallback.example.net" in urls
+    assert len(urls) == len(set(urls)), "candidates should be deduplicated"
+
+    top = results[0]
+    assert top.metadata["trust"] == "high"
+    assert top.metadata["feed"] == "https://example.com/feed.xml"
+    assert top.score > 0


### PR DESCRIPTION
## Summary
- add an engine.discovery package with registry gather logic and an rss_hub strategy to score feed entries
- expose a crawler_api.seeds_from_registry planner tool so RSS-derived candidates are available during cold start
- cover the new helpers with unit tests and update existing tool-dispatcher tests

## Testing
- pytest tests/engine/test_discovery_gather.py tests/server/test_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d21ee572c88321864637124be2ce5f