### PR TITLE
Refactor seed registry schema and loader

### DIFF
--- a/docs/registry_structure.md
+++ b/docs/registry_structure.md
@@ -1,0 +1,104 @@
+# Seed Registry Schema
+
+The registry stored at `seeds/registry.yaml` defines curated entrypoints for
+bootstrapping discovery. The schema is intentionally data-first so that new
+collections can be added without changing Python code. This document explains
+how the file is structured and how defaults cascade through the hierarchy.
+
+## Top-level keys
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `version` | ✅ | Schema revision. Increment when making breaking structural changes. |
+| `crawl_defaults` | ✅ | Mapping of default attributes applied to every source (e.g. `strategy`, `trust`, throttling hints). |
+| `directories` | ✅ | Mapping of named collections (e.g. `news`, `github_topics`). Each directory groups related sources and can set its own defaults. |
+| `sources` | Optional | Legacy list of sources processed after `directories`. Use only when a collection does not fit an existing directory. |
+
+## Default resolution order
+
+Values are merged in the following order (later entries win and enrich the
+previous ones):
+
+1. Global `crawl_defaults`
+2. Directory-level `defaults`
+3. Inline directory attributes (`kind`, `strategy`, `trust`, `tags`)
+4. Individual source fields
+5. Automatic metadata such as `collection`
+
+List-like `tags` are merged rather than replaced and normalized to lowercase
+with duplicates removed. All other values are deep-copied so the loader never
+shares mutable references between entries.
+
+## Directory definition
+
+Each directory entry has the following shape:
+
+```yaml
+<directory-slug>:
+  description: >-
+    Human-readable context for the collection (appears in docs only).
+  defaults:
+    kind: editorial
+    strategy: feed
+    trust: high
+    tags:
+      - news
+      - rss
+  sources:
+    - id: news_example
+      entrypoints:
+        - https://example.com/feed.xml
+      trust: medium  # overrides directory default
+      cadence: hourly
+```
+
+* `description` (optional) documents intent.
+* `defaults` (optional) overrides the global defaults for the directory.
+* Inline keys `kind`, `strategy`, `trust`, and `tags` are also accepted for
+  convenience and are merged into the directory defaults.
+* `sources` is a list of mappings where each entry **must** specify:
+  * `id` – globally unique identifier.
+  * `entrypoints` – a URL string or list of URL strings (full `http(s)` paths only).
+
+Other keys (e.g. `title`, `cadence`, `follow_sitemaps`) are preserved and exposed
+through the loader as `extras`.
+
+Every source automatically receives a `collection` extra that mirrors the
+directory slug so downstream systems know the origin grouping.
+
+## Trust level guidance
+
+The canonical registry currently defines the following high-level directories:
+
+* `news` — editorial RSS feeds from organizations like AP, Reuters, NPR, and BBC
+  with `trust: high`.
+* `wikipedia_portals` — curated encyclopedia portals with `trust: high` (or
+  `medium` for broader community-maintained areas).
+* `github_topics` — GitHub topic hubs with `trust: medium`.
+* `awesome_lists` — maintained Awesome lists, defaulting to `trust: high`.
+* `sitemap_discovery` — robots.txt seeds for sitemap enumeration with
+  `trust: medium` and `follow_sitemaps: true`.
+
+Use these trust defaults when adding new sources unless you have explicit review
+signals to justify a change.
+
+## Adding a new source
+
+1. Pick the appropriate directory. If none exists, create a new directory with a
+   descriptive slug and defaults.
+2. Ensure the `id` is unique across the entire file. Prefixes such as
+   `news_`, `github_topic_`, or `sitemap_` help avoid collisions.
+3. Provide full absolute URLs for `entrypoints`. Avoid relative paths.
+4. Set any overrides (e.g. `trust`, `strategy`, `tags`) required for the source.
+5. Update documentation when introducing a new directory or schema feature.
+
+## Validation
+
+Running the unit tests ensures the loader can interpret the schema:
+
+```bash
+pytest tests/test_server_seeds_loader.py
+```
+
+The loader will raise `ValueError` if mandatory fields are missing, entrypoint
+URLs are invalid, or duplicate IDs are introduced.

--- a/seeds/registry.yaml
+++ b/seeds/registry.yaml
@@ -1,47 +1,169 @@
-sources:
-  - id: developer_docs
-    kind: curated
-    strategy: sitemap
-    entrypoints:
-      - https://developer.mozilla.org/
-      - https://docs.python.org/3/
-      - https://developer.apple.com/documentation/
-    trust: high
-  - id: open_source_hubs
-    kind: aggregator
-    strategy: feed
-    entrypoints:
-      - https://github.com/trending
-      - https://gitlab.com/explore
-      - https://bitbucket.org/product/discover
-    trust: medium
-  - id: technical_news
-    kind: editorial
-    strategy: headlines
-    entrypoints:
-      - https://news.ycombinator.com/
-      - https://www.theverge.com/tech
-      - https://www.techmeme.com/
-    trust: medium
-  - id: community_qna
-    kind: forum
-    strategy: crawl
-    entrypoints:
-      - https://stackoverflow.com/questions
-      - https://superuser.com/questions
-      - https://serverfault.com/questions
-    trust: medium
-  - id: government_open_data
-    kind: public_sector
-    strategy: catalog
-    entrypoints:
-      - https://data.gov/
-      - https://data.europa.eu/en
-      - https://www.data.gov.uk/
-    trust: high
-  - id: sitemap-hunter
-    kind: crawler
-    strategy: sitemap
-    entrypoints:
-      - https://example.com/robots.txt
-    trust: medium
+version: 1
+crawl_defaults:
+  obey_robots: true
+  retry_backoff_seconds: 300
+  strategy: crawl
+  trust: medium
+directories:
+  news:
+    description: >-
+      High-quality global and national newsroom feeds for timely reporting
+      across politics, science, and world events.
+    defaults:
+      kind: editorial
+      strategy: feed
+      trust: high
+      tags:
+        - news
+        - rss
+    sources:
+      - id: news_ap_top
+        title: Associated Press – Top News
+        entrypoints:
+          - https://apnews.com/hub/ap-top-news?format=atom
+          - https://feeds.apnews.com/apf-topnews
+        cadence: hourly
+      - id: news_reuters_world
+        title: Reuters – World News
+        entrypoints:
+          - https://feeds.reuters.com/reuters/worldNews
+        cadence: hourly
+      - id: news_npr_top
+        title: NPR – Top Stories
+        entrypoints:
+          - https://feeds.npr.org/1001/rss.xml
+        cadence: hourly
+      - id: news_bbc_world
+        title: BBC – World News
+        entrypoints:
+          - https://feeds.bbci.co.uk/news/world/rss.xml
+        cadence: hourly
+  wikipedia_portals:
+    description: >-
+      Wikipedia portals that summarize curated knowledge domains for
+      broad topical coverage and contextual timelines.
+    defaults:
+      kind: knowledge-base
+      strategy: portal
+      trust: high
+      tags:
+        - wikipedia
+        - reference
+    sources:
+      - id: wikipedia_current_events
+        title: Wikipedia – Current Events Portal
+        entrypoints:
+          - https://en.wikipedia.org/wiki/Portal:Current_events
+        cadence: daily
+      - id: wikipedia_science
+        title: Wikipedia – Science Portal
+        entrypoints:
+          - https://en.wikipedia.org/wiki/Portal:Science
+        cadence: weekly
+      - id: wikipedia_technology
+        title: Wikipedia – Technology Portal
+        entrypoints:
+          - https://en.wikipedia.org/wiki/Portal:Technology
+        cadence: weekly
+      - id: wikipedia_society
+        title: Wikipedia – Society Portal
+        entrypoints:
+          - https://en.wikipedia.org/wiki/Portal:Society
+        trust: medium
+        cadence: weekly
+  github_topics:
+    description: >-
+      GitHub topic hubs that aggregate active repositories, tutorials, and
+      learning materials for developers.
+    defaults:
+      kind: developer
+      strategy: curated
+      trust: medium
+      tags:
+        - github
+        - topics
+    sources:
+      - id: github_topic_machine_learning
+        title: GitHub Topic – Machine Learning
+        entrypoints:
+          - https://github.com/topics/machine-learning
+        cadence: weekly
+      - id: github_topic_cybersecurity
+        title: GitHub Topic – Cybersecurity
+        entrypoints:
+          - https://github.com/topics/cybersecurity
+        cadence: weekly
+      - id: github_topic_web_development
+        title: GitHub Topic – Web Development
+        entrypoints:
+          - https://github.com/topics/web-development
+        cadence: weekly
+      - id: github_topic_ai_safety
+        title: GitHub Topic – AI Safety
+        entrypoints:
+          - https://github.com/topics/ai-safety
+        cadence: weekly
+  awesome_lists:
+    description: >-
+      Maintained Awesome lists that curate high-signal resources for
+      practitioners across ecosystems.
+    defaults:
+      kind: curated
+      strategy: list
+      trust: high
+      tags:
+        - awesome
+        - github
+    sources:
+      - id: awesome_master
+        title: Awesome – Master Index
+        entrypoints:
+          - https://github.com/sindresorhus/awesome
+        cadence: weekly
+      - id: awesome_python
+        title: Awesome – Python
+        entrypoints:
+          - https://github.com/vinta/awesome-python
+        cadence: weekly
+      - id: awesome_machine_learning
+        title: Awesome – Machine Learning
+        entrypoints:
+          - https://github.com/josephmisiti/awesome-machine-learning
+        cadence: weekly
+      - id: awesome_security
+        title: Awesome – Security
+        entrypoints:
+          - https://github.com/sbilly/awesome-security
+        cadence: weekly
+  sitemap_discovery:
+    description: >-
+      Robots.txt entrypoints for broad sitemap discovery across trusted
+      institutional domains.
+    defaults:
+      kind: crawler
+      strategy: sitemap
+      trust: medium
+      tags:
+        - discovery
+        - sitemap
+    sources:
+      - id: sitemap_nasa
+        title: NASA Robots.txt
+        entrypoints:
+          - https://www.nasa.gov/robots.txt
+        follow_sitemaps: true
+      - id: sitemap_white_house
+        title: The White House Robots.txt
+        entrypoints:
+          - https://www.whitehouse.gov/robots.txt
+        follow_sitemaps: true
+      - id: sitemap_european_union
+        title: European Union Robots.txt
+        entrypoints:
+          - https://europa.eu/robots.txt
+        follow_sitemaps: true
+      - id: sitemap_united_nations
+        title: United Nations Robots.txt
+        entrypoints:
+          - https://www.un.org/robots.txt
+        follow_sitemaps: true

--- a/tests/test_server_seeds_loader.py
+++ b/tests/test_server_seeds_loader.py
@@ -7,30 +7,48 @@ def test_load_seed_registry_normalizes(tmp_path):
     registry = tmp_path / "registry.yaml"
     registry.write_text(
         """
+        version: 1
+        crawl_defaults:
+          strategy: Crawl
+          trust: Medium
+          tags:
+            - Global
+        directories:
+          knowledge:
+            defaults:
+              kind: CURATED
+              strategy: Sitemap
+              tags:
+                - Docs
+            sources:
+              - id: Docs
+                entrypoints:
+                  - https://example.com/docs
+                  - { url: https://example.com/docs }
+                  - https://example.com/docs?ref=dup
+                trust: High
+                notes: keep-me
+                tags:
+                  - Primary
+              - id: numeric_trust
+                entrypoints: https://example.net/api
+                trust: 0.75
         sources:
-          - id: Docs
-            kind: CURATED
-            strategy: Sitemap
+          - id: legacy
+            kind: aggregator
+            strategy: feed
             entrypoints:
-              - https://example.com/docs
-              - { url: https://example.com/docs }
-              - https://example.com/docs?ref=dup
-            trust: High
-            notes: keep-me
-          - id: numeric_trust
-            kind: mirror
-            strategy: manual
-            entrypoints: https://example.net/api
-            trust: 0.75
+              - https://legacy.example.org
+            trust: low
         """,
         encoding="utf-8",
     )
 
     entries = load_seed_registry(registry)
-    assert len(entries) == 2
+    assert len(entries) == 3
+    by_id = {entry.id: entry for entry in entries}
 
-    docs_entry = entries[0]
-    assert docs_entry.id == "Docs"
+    docs_entry = by_id["Docs"]
     assert docs_entry.kind == "curated"
     assert docs_entry.strategy == "sitemap"
     assert docs_entry.entrypoints == (
@@ -38,11 +56,21 @@ def test_load_seed_registry_normalizes(tmp_path):
         "https://example.com/docs?ref=dup",
     )
     assert docs_entry.trust == "high"
-    assert docs_entry.extras == {"notes": "keep-me"}
+    assert docs_entry.extras["notes"] == "keep-me"
+    assert docs_entry.extras["collection"] == "knowledge"
+    assert docs_entry.extras["tags"] == ["global", "docs", "primary"]
 
-    numeric_entry = entries[1]
+    numeric_entry = by_id["numeric_trust"]
+    assert numeric_entry.strategy == "sitemap"
     assert numeric_entry.trust == pytest.approx(0.75)
     assert numeric_entry.entrypoints == ("https://example.net/api",)
+    assert numeric_entry.extras["tags"] == ["global", "docs"]
+
+    legacy_entry = by_id["legacy"]
+    assert legacy_entry.kind == "aggregator"
+    assert legacy_entry.strategy == "feed"
+    assert legacy_entry.entrypoints == ("https://legacy.example.org",)
+    assert "collection" not in legacy_entry.extras
 
 
 def test_load_seed_registry_accepts_top_level_array(tmp_path):
@@ -68,19 +96,24 @@ def test_load_seed_registry_detects_duplicates(tmp_path):
     registry = tmp_path / "registry.yaml"
     registry.write_text(
         """
-        sources:
-          - id: dup
-            kind: curated
-            strategy: crawl
-            entrypoints:
-              - https://example.com
-            trust: low
-          - id: dup
-            kind: curated
-            strategy: crawl
-            entrypoints:
-              - https://example.net
-            trust: low
+        version: 1
+        directories:
+          dup_one:
+            defaults:
+              kind: curated
+              strategy: crawl
+            sources:
+              - id: dup
+                entrypoints:
+                  - https://example.com
+          dup_two:
+            defaults:
+              kind: curated
+              strategy: crawl
+            sources:
+              - id: dup
+                entrypoints:
+                  - https://example.net
         """,
         encoding="utf-8",
     )
@@ -98,13 +131,16 @@ def test_load_seed_registry_rejects_relative_entrypoints(tmp_path):
     registry = tmp_path / "registry.yaml"
     registry.write_text(
         """
-        sources:
-          - id: bad
-            kind: curated
-            strategy: crawl
-            entrypoints:
-              - /relative/path
-            trust: low
+        version: 1
+        directories:
+          invalid:
+            defaults:
+              kind: curated
+              strategy: crawl
+            sources:
+              - id: bad
+                entrypoints:
+                  - /relative/path
         """,
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- replace the seed registry with a versioned schema that includes global crawl defaults and curated directories for news, Wikipedia portals, GitHub topics, Awesome lists, and sitemap discovery
- enhance the server seed loader to understand directory defaults, merge tag metadata, and surface collection information while keeping legacy formats working
- document the registry layout for future contributors and update the loader unit tests to cover the new structure

## Testing
- pytest tests/test_server_seeds_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d220f0d6a083219ed0bcfffc2f99e4