### PR TITLE
Add planner fallback support and regression test

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,6 +99,7 @@ planner_agent = PlannerAgent(
     llm=planner_llm,
     tools=tool_dispatcher,
     default_model=ENGINE_CONFIG.models.llm_primary,
+    fallback_model=ENGINE_CONFIG.models.llm_fallback,
     max_iterations=6,
 )
 


### PR DESCRIPTION
## Summary
- add fallback support in PlannerAgent with explicit logging and model tracking
- wire the planner fallback model through the Flask app and search API responses
- cover fallback behaviour with an API regression test for the search endpoint

## Testing
- pytest tests/api/test_search_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d2dbd7bdbc8321861e22ef772536cd