### PR TITLE
Add chat logging and tests

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -57,6 +57,11 @@ def create_app() -> Flask:
     config.ensure_dirs()
     config.log_summary()
 
+    chat_logger = logging.getLogger("backend.app.api.chat")
+    chat_logger.setLevel(config.chat_log_level)
+    chat_logger.propagate = True
+    app.config.setdefault("CHAT_LOGGER", chat_logger)
+
     db = get_db(config.learned_web_db_path)
     runner = JobRunner(config.logs_dir)
     manager = FocusedCrawlManager(config, runner, db)

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Iterable, Iterator
+import logging
+from typing import Iterable, Iterator, List
 
 import requests
 from flask import Blueprint, Response, current_app, request, stream_with_context
@@ -13,16 +14,82 @@ from ..config import AppConfig
 bp = Blueprint("chat_api", __name__, url_prefix="/api")
 
 
+LOGGER = logging.getLogger(__name__)
+_MAX_LOGGED_MESSAGES = 5
+_MAX_MESSAGE_PREVIEW = 200
+_MAX_ERROR_PREVIEW = 500
+
+
+def _resolve_logger() -> logging.Logger:
+    """Return the logger configured for chat telemetry."""
+
+    try:
+        app = current_app._get_current_object()
+    except RuntimeError:  # pragma: no cover - fallback for out-of-context use
+        return LOGGER
+    configured = app.config.get("CHAT_LOGGER")
+    if configured is not None:
+        return configured
+    return app.logger
+
+
+def _truncate(value: str, max_length: int) -> str:
+    if len(value) <= max_length:
+        return value
+    return value[: max_length - 3] + "..."
+
+
+def _sanitize_messages(messages: List[dict]) -> list[dict[str, object]]:
+    sanitized: list[dict[str, object]] = []
+    for message in messages[:_MAX_LOGGED_MESSAGES]:
+        if not isinstance(message, dict):
+            sanitized.append({"type": type(message).__name__})
+            continue
+        role = message.get("role")
+        role_str = role if isinstance(role, str) else repr(role)
+        content = message.get("content")
+        if isinstance(content, str):
+            preview = _truncate(content, _MAX_MESSAGE_PREVIEW)
+            char_count: int | None = len(content)
+        elif content is None:
+            preview = ""
+            char_count = 0
+        else:
+            preview = _truncate(str(content), _MAX_MESSAGE_PREVIEW)
+            char_count = None
+        sanitized.append({
+            "role": role_str,
+            "preview": preview,
+            "chars": char_count,
+        })
+    if len(messages) > _MAX_LOGGED_MESSAGES:
+        sanitized.append({"omitted": len(messages) - _MAX_LOGGED_MESSAGES})
+    return sanitized
+
+
 def _ollama_chat_stream(url: str, payload: dict) -> Iterable[str]:
+    logger = _resolve_logger()
+    logger.info(
+        "forwarding chat request to ollama url=%s model=%s",
+        url,
+        payload.get("model") or "<default>",
+    )
     try:
         response = requests.post(url, json=payload, stream=True, timeout=120)
     except requests.RequestException as exc:
+        logger.exception("ollama chat request failed")
         message = json.dumps({"type": "error", "content": str(exc)})
         yield f"data: {message}\n\n"
         return
 
     if response.status_code >= 400:
-        content = response.text.strip() or f"HTTP {response.status_code}"
+        content_raw = response.text.strip() or f"HTTP {response.status_code}"
+        content = _truncate(content_raw, _MAX_ERROR_PREVIEW)
+        logger.error(
+            "ollama chat responded with HTTP %s: %s",
+            response.status_code,
+            content,
+        )
         message = json.dumps({"type": "error", "content": content})
         yield f"data: {message}\n\n"
         return
@@ -33,6 +100,7 @@ def _ollama_chat_stream(url: str, payload: dict) -> Iterable[str]:
         try:
             chunk = json.loads(line.decode("utf-8"))
         except json.JSONDecodeError:
+            logger.debug("discarding non-json chunk from ollama: %s", line)
             continue
         message = chunk.get("message", {})
         content = message.get("content")
@@ -53,8 +121,23 @@ def chat_stream() -> Response:
     payload = request.get_json(silent=True) or {}
     messages = payload.get("messages")
     if not isinstance(messages, list):
-        return Response(json.dumps({"error": "messages must be a list"}), status=400, mimetype="application/json")
+        _resolve_logger().warning(
+            "chat request rejected due to invalid messages payload: %s",
+            type(messages).__name__,
+        )
+        return Response(
+            json.dumps({"error": "messages must be a list"}),
+            status=400,
+            mimetype="application/json",
+        )
     model = (payload.get("model") or "").strip() or None
+
+    logger = _resolve_logger()
+    logger.info(
+        "chat request received model=%s prompts=%s",
+        model or "<default>",
+        json.dumps(_sanitize_messages(messages), ensure_ascii=False),
+    )
 
     config: AppConfig = current_app.config["APP_CONFIG"]
     url = f"{config.ollama_url}/api/chat"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,7 @@ class AppConfig:
     ollama_url: str
     crawl_use_playwright: str
     use_llm_rerank: bool
+    chat_log_level: int
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -66,6 +67,8 @@ class AppConfig:
         ollama_url = os.getenv("OLLAMA_URL", os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")).rstrip("/")
         crawl_use_playwright = os.getenv("CRAWL_USE_PLAYWRIGHT", "auto").lower()
         use_llm_rerank = os.getenv("USE_LLM_RERANK", "false").lower() in {"1", "true", "yes", "on"}
+        chat_log_level_name = os.getenv("CHAT_LOG_LEVEL", "INFO").upper()
+        chat_log_level = getattr(logging, chat_log_level_name, logging.INFO)
 
         return cls(
             index_dir=index_dir,
@@ -89,6 +92,7 @@ class AppConfig:
             ollama_url=ollama_url,
             crawl_use_playwright=crawl_use_playwright,
             use_llm_rerank=use_llm_rerank,
+            chat_log_level=chat_log_level,
         )
 
     def ensure_dirs(self) -> None:
@@ -121,6 +125,7 @@ class AppConfig:
             "crawl_use_playwright": self.crawl_use_playwright,
             "use_llm_rerank": self.use_llm_rerank,
             "learned_web_db_path": str(self.learned_web_db_path),
+            "chat_log_level": logging.getLevelName(self.chat_log_level),
         }
         LOGGER.info("runtime configuration: %s", json.dumps(payload, sort_keys=True))
 

--- a/tests/api/test_chat_api.py
+++ b/tests/api/test_chat_api.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+from flask import Flask
+
+from backend.app.api import chat as chat_module
+from backend.app.api.chat import bp as chat_bp
+
+
+class DummyResponse:
+    def __init__(self, lines: list[bytes], status_code: int = 200, text: str = "") -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.text = text
+
+    def iter_lines(self):
+        yield from self._lines
+
+
+def test_chat_logging_records_prompt(caplog, monkeypatch):
+    app = Flask(__name__)
+    app.register_blueprint(chat_bp)
+    app.testing = True
+
+    chat_logger = logging.getLogger("test.chat")
+    chat_logger.setLevel(logging.INFO)
+    chat_logger.propagate = True
+    app.config.update(
+        APP_CONFIG=SimpleNamespace(ollama_url="http://ollama"),
+        CHAT_LOGGER=chat_logger,
+    )
+
+    payload = {
+        "model": "llama2",
+        "messages": [
+            {"role": "user", "content": "Hello world"},
+        ],
+    }
+
+    streamed_lines = [
+        json.dumps({"message": {"content": "Hi"}, "done": False}).encode(),
+        json.dumps({"done": True, "total_duration": 1, "load_duration": 1}).encode(),
+    ]
+
+    captured = {}
+
+    def fake_post(url, json, stream, timeout):  # noqa: ANN001 - requests compatibility
+        captured.update({"url": url, "json": json, "stream": stream, "timeout": timeout})
+        return DummyResponse(streamed_lines)
+
+    monkeypatch.setattr(chat_module.requests, "post", fake_post)
+
+    client = app.test_client()
+    with caplog.at_level(logging.INFO, logger=chat_logger.name):
+        response = client.post("/api/chat", json=payload)
+        assert response.status_code == 200
+        body = b"".join(response.response)
+
+    assert body
+    assert captured["url"] == "http://ollama/api/chat"
+    assert captured["json"]["messages"] == payload["messages"]
+    assert captured["json"]["model"] == "llama2"
+
+    messages = [record.getMessage() for record in caplog.records if record.name == chat_logger.name]
+    assert any("chat request received" in message and "Hello world" in message for message in messages)
+    assert any("forwarding chat request to ollama" in message for message in messages)


### PR DESCRIPTION
## Summary
- add structured logging to the chat endpoint and Ollama stream helper, including sanitised prompts and error reporting
- expose a configurable chat logger via AppConfig so verbosity can be tuned with CHAT_LOG_LEVEL
- cover the new logging behaviour with a Flask test-client unit test that inspects emitted log messages

## Testing
- pytest tests/api/test_chat_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d2defc4b5083219e378472b415c4ea