### PR TITLE
Fix reindex entrypoints to ensure backend imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ PY:=$(VENV)/bin/python
 PIP:=$(VENV)/bin/pip
 PLAYWRIGHT:=$(VENV)/bin/playwright
 
+REPO_ROOT := $(shell pwd)
+export PYTHONPATH := $(REPO_ROOT)$(if $(PYTHONPATH),:$(PYTHONPATH))
+
 setup:
 	./scripts/ensure_py311.sh $(PYTHON)
 	@test -d $(VENV) || $(PYTHON) -m venv $(VENV)
@@ -36,7 +39,7 @@ crawl:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; INDEX_DIR="${INDEX_DIR:-./data/index}"; CRAWL_STORE="${CRAWL_STORE:-./data/crawl}"; export INDEX_DIR CRAWL_STORE URL SEEDS_FILE MAX_PAGES; exec $(PY) bin/crawl.py'
 
 reindex:
-	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/reindex_incremental.py'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) -m bin.reindex_incremental'
 
 search:
 	@if [ -z "$$Q" ]; then echo "Set Q=\"your query\"" >&2; exit 1; fi
@@ -50,7 +53,7 @@ normalize:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/normalize.py'
 
 reindex-incremental:
-	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/reindex_incremental.py'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) -m bin.reindex_incremental'
 
 seeds:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/seeds_prepare.py'

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Export variables via `.env` (auto-loaded by `make` targets) or the shell:
 - `make dev` – loads `.env`, runs `bin/dev_check.py`, and starts the Flask dev server with auto-reload.
 - `make crawl` – wraps `python bin/crawl.py`; accepts `URL`, `SEEDS_FILE`, and respects `.env` overrides.
 - `make reindex` – rebuilds the Whoosh index (use `make index-inc` for incremental updates).
+- `python -m bin.reindex_incremental` and `python bin/reindex_incremental.py` are interchangeable entrypoints when you need to run the incremental job manually.
 - `make search` – executes the CLI search client with optional `LIMIT`.
 - `make focused` – runs `bin/crawl_focused.py` for a specific query (`Q="..."`) with optional `BUDGET`, `USE_LLM`, and `MODEL` overrides.
 - `make llm-status` – quick health check for the Ollama HTTP API exposed through Flask.
@@ -288,7 +289,7 @@ Export variables via `.env` (auto-loaded by `make` targets) or the shell:
 ## Troubleshooting
 
 - **“No seeds provided”** – pass `URL=...` to `make crawl` or populate `crawler/seeds.txt`.
-- **Empty results** – confirm `data/crawl/normalized.jsonl` exists, then run `make reindex`.
+- **Empty results** – confirm `data/crawl/normalized.jsonl` exists, then run `make reindex` (or the equivalent `python -m bin.reindex_incremental`).
 - **Playwright prompts** – `make setup` installs Chromium automatically; re-run if browsers are missing.
 - **Non-3.11 Python** – run `./scripts/ensure_py311.sh python3` before `make setup`.
 

--- a/bin/reindex.py
+++ b/bin/reindex.py
@@ -6,14 +6,28 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pathlib
 import shutil
 import sys
 import time
 from pathlib import Path
 from typing import Iterable, List
 
-from backend.app.config import AppConfig
-from backend.app.indexer.incremental import incremental_index
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from backend.app.config import AppConfig
+    from backend.app.indexer.incremental import incremental_index
+except ModuleNotFoundError as exc:  # pragma: no cover - defensive path hints
+    if exc.name == "backend":
+        msg = (
+            "Unable to import 'backend'. Ensure the repository root is on PYTHONPATH or "
+            "invoke this script via 'python -m bin.reindex'."
+        )
+        print(msg, file=sys.stderr)
+    raise
 
 INDEX_INC_WINDOW_MIN = int(os.getenv("INDEX_INC_WINDOW_MIN", "60"))
 

--- a/bin/reindex_incremental.py
+++ b/bin/reindex_incremental.py
@@ -3,11 +3,20 @@
 
 from __future__ import annotations
 
+import pathlib
 import sys
 
-def main() -> None:
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    from .reindex import run
+except ImportError:  # pragma: no cover - fallback for direct execution
     from reindex import run
 
+
+def main() -> None:
     run("incremental")
 
 

--- a/tests/test_reindex_entrypoints.py
+++ b/tests/test_reindex_entrypoints.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "invocation",
+    (
+        [sys.executable, "-m", "bin.reindex_incremental"],
+        [sys.executable, "bin/reindex_incremental.py"],
+    ),
+)
+def test_incremental_reindex_entrypoints(tmp_path: Path, invocation: list[str]) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    normalized = data_dir / "normalized.jsonl"
+    payload = {
+        "url": "https://example.com/",
+        "lang": "en",
+        "title": "Example",
+        "h1h2": "Example heading",
+        "body": "Example body text",
+        "content_hash": "abc123",
+        "fetched_at": time.time(),
+        "outlinks": ["https://example.org/"],
+    }
+    normalized.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.update({
+        "DATA_DIR": str(data_dir),
+        "INDEX_INC_WINDOW_MIN": "120",
+    })
+
+    result = subprocess.run(
+        invocation,
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
+    index_dir = Path(env["DATA_DIR"]) / "index"
+    assert index_dir.exists(), f"index directory missing\nstdout={result.stdout}\nstderr={result.stderr}"


### PR DESCRIPTION
## Summary
- ensure the reindex scripts add the repository root to sys.path and give a helpful tip when backend imports fail
- update the Makefile to export PYTHONPATH, invoke the incremental reindex via module execution, and document the supported entrypoints in the README
- add a pytest smoke test that exercises both the module and direct-script reindex invocations with a temporary data dir

## Testing
- pytest tests/test_reindex_entrypoints.py

------
https://chatgpt.com/codex/tasks/task_e_68d32ef2a9688321a01c8b5c03810742