### PR TITLE
Add Python docs to seed registry

### DIFF
--- a/seeds/registry.yaml
+++ b/seeds/registry.yaml
@@ -135,6 +135,24 @@ directories:
         entrypoints:
           - https://github.com/sbilly/awesome-security
         cadence: weekly
+  language_docs:
+    description: >-
+      Official documentation portals for widely used programming
+      languages and runtimes. These canonical sources provide
+      authoritative API references and tutorials for developers.
+    defaults:
+      kind: documentation
+      strategy: docs
+      trust: high
+      tags:
+        - docs
+        - developer
+    sources:
+      - id: docs_python
+        title: Python Documentation
+        entrypoints:
+          - https://docs.python.org/3/
+        cadence: monthly
   sitemap_discovery:
     description: >-
       Robots.txt entrypoints for broad sitemap discovery across trusted


### PR DESCRIPTION
## Summary
- add a language_docs directory to the seed registry configuration
- seed the registry with the canonical Python documentation portal
- ensure focused crawl discovery emits official docs when building seeds

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d33418a19483218ed4d351b44d02a8