### PR TITLE
Fix planner LLM JSON parsing for dict responses

### DIFF
--- a/tests/server/test_agent.py
+++ b/tests/server/test_agent.py
@@ -56,6 +56,23 @@ def test_json_client_parses_code_fence():
     assert result["answer"] == "ok"
 
 
+def test_json_client_accepts_object_payload():
+    payload = {
+        "message": {
+            "content": {
+                "type": "final",
+                "answer": "structured",
+                "sources": ["https://example"],
+            }
+        }
+    }
+    client = OllamaJSONClient(base_url="http://fake", default_model="llama", session=FakeSession(payload))
+    result = client.chat_json([{"role": "user", "content": "hi"}])
+    assert result["type"] == "final"
+    assert result["answer"] == "structured"
+    assert result["sources"] == ["https://example"]
+
+
 class FakeVectorStore:
     def __init__(self):
         self.upserts = []


### PR DESCRIPTION
## Summary
- allow the planner's Ollama JSON client to accept object or string content fields from /api/chat
- extend normalization to serialize mapping/list payloads before parsing
- add a regression test covering structured JSON responses from Ollama

## Testing
- python -m pytest tests/server/test_agent.py::test_json_client_accepts_object_payload

------
https://chatgpt.com/codex/tasks/task_e_68d35239c3208321a7414536bb5bb822