### PR TITLE
Handle blank chroma env values

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -80,10 +80,15 @@ class EngineConfig:
             min_hits=int(retrieval.get("min_hits", 1)),
             similarity_threshold=float(retrieval.get("similarity_threshold", 0.2)),
         )
-        persist_dir_value = os.getenv(
-            "CHROMA_PERSIST_DIR", index.get("persist_dir", "data/chroma")
-        )
-        db_path_value = os.getenv("CHROMA_DB_PATH", index.get("db_path", "data/index.duckdb"))
+        persist_dir_env = os.getenv("CHROMA_PERSIST_DIR")
+        if persist_dir_env is not None and not persist_dir_env.strip():
+            persist_dir_env = None
+        persist_dir_value = persist_dir_env or index.get("persist_dir", "data/chroma")
+
+        db_path_env = os.getenv("CHROMA_DB_PATH")
+        if db_path_env is not None and not db_path_env.strip():
+            db_path_env = None
+        db_path_value = db_path_env or index.get("db_path", "data/index.duckdb")
         index_cfg = IndexConfig(
             persist_dir=cls._resolve_path(persist_dir_value, base_dir),
             db_path=cls._resolve_path(db_path_value, base_dir),

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -1,0 +1,59 @@
+"""Tests for engine configuration loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.config import EngineConfig
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+models:
+  llm_primary: test-primary
+  llm_fallback: null
+  embed: test-embed
+ollama:
+  base_url: http://localhost
+retrieval:
+  k: 1
+  min_hits: 1
+  similarity_threshold: 0.0
+index:
+  persist_dir: ./data/chroma
+  db_path: ./data/index.duckdb
+crawl:
+  user_agent: test-agent
+  request_timeout: 1
+  read_timeout: 1
+  max_pages: 1
+  sleep_seconds: 0.0
+""".strip()
+    )
+    return config_path
+
+
+def test_blank_chroma_env_uses_config_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setenv("CHROMA_PERSIST_DIR", "")
+    monkeypatch.setenv("CHROMA_DB_PATH", " \t ")
+
+    cfg = EngineConfig.from_yaml(config_path)
+
+    assert cfg.index.persist_dir == config_path.parent / "data/chroma"
+    assert cfg.index.db_path == config_path.parent / "data/index.duckdb"
+
+
+def test_non_empty_env_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    monkeypatch.setenv("CHROMA_PERSIST_DIR", "./custom/chroma")
+    monkeypatch.setenv("CHROMA_DB_PATH", "./custom/index.duckdb")
+
+    cfg = EngineConfig.from_yaml(config_path)
+
+    assert cfg.index.persist_dir == config_path.parent / "custom/chroma"
+    assert cfg.index.db_path == config_path.parent / "custom/index.duckdb"


### PR DESCRIPTION
## Summary
- treat empty CHROMA_PERSIST_DIR and CHROMA_DB_PATH values as unset when loading configuration
- add regression tests covering blank and non-empty environment overrides

## Testing
- pytest tests/engine/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d492f7c3588321a1b19cbc7d1d11cd