### PR TITLE
Improve planner LLM fallback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ make llm-models   # lists models returned by /api/tags
 The default behaviour stays fully local: no external APIs are contacted unless you explicitly enable Ollama. Set `SMART_USE_LLM=true`
 in `.env` if you want the toggle pre-enabled for every user.
 
+### Planner LLM fallback
+
+- `models.llm_primary` in `config.yaml` selects the planner's primary Ollama model.
+- `models.llm_fallback` defines an optional backup automatically used when the primary returns `404`/`model not found`.
+- Pull at least one model locally: `ollama pull gpt-oss:20b` or `ollama pull gemma3:27b`.
+- When both models are missing the `/api/search` planner response stays `200` and returns `{"type":"final","answer":"Planner LLM is unavailable."}` so the UI can degrade gracefully.
+
 ## Diagnostics snapshot API
 
 Operators can capture the current repository state and runtime logs without leaving the browser. `POST /api/diagnostics` enqueues a

--- a/server/logging_utils.py
+++ b/server/logging_utils.py
@@ -1,0 +1,13 @@
+"""Lightweight logging helpers used by server components."""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger with a consistent namespace."""
+    return logging.getLogger(name)
+
+
+__all__ = ["get_logger"]


### PR DESCRIPTION
## Summary
- add a reusable logger helper and improve planner fallback logic with clear logging
- surface planner LLM fallback wiring and error responses in the search API and documentation
- tighten Ollama JSON client error handling and extend tests for planner fallback/error scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d49abcf9388321961eba66d144ab03