### PR TITLE
Add automatic bootstrap indexing for cold start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,7 @@ run:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) -m flask --app app --debug run'
 
 index:
-	@if [ -z "$$Q" ]; then echo "Set Q=\"seed query\"" >&2; exit 1; fi
-	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; . $(VENV)/bin/activate; python -c "import os; from app import coldstart; query = os.environ.get('"'"Q"'"', '"'"""'"'); count = coldstart.build_index(query); print(f'"'"Indexed {count} pages for query: {query}"'"')"'
+	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; . $(VENV)/bin/activate; exec $(PY) bin/bootstrap_index.py'
 
 clean-index:
 	@mkdir -p "$(WHOOSH_DIR)"

--- a/bin/bootstrap_index.py
+++ b/bin/bootstrap_index.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Bootstrap the vector index using configured cold-start queries."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Iterable
+
+
+def _as_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _iter_queries(raw: Iterable[str]) -> Iterable[str]:
+    for item in raw:
+        text = (item or "").strip()
+        if text:
+            yield text
+
+
+def main() -> int:
+    os.environ.setdefault("CHROMADB_DISABLE_TELEMETRY", "1")
+
+    try:
+        from app import ENGINE_CONFIG, coldstart, embed_manager, embedder
+    except Exception as exc:  # pragma: no cover - import failure should be obvious
+        print(f"Failed to import application modules: {exc}", file=sys.stderr)
+        return 2
+
+    logger = logging.getLogger("bootstrap_index")
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+    env_query = (os.getenv("Q") or "").strip()
+    use_llm_env = os.getenv("USE_LLM")
+    llm_model_env = (os.getenv("MODEL") or os.getenv("LLM_MODEL") or "").strip() or None
+
+    bootstrap_cfg = ENGINE_CONFIG.bootstrap
+
+    if env_query:
+        queries = [env_query]
+        use_llm = _as_bool(use_llm_env)
+        llm_model = llm_model_env or (bootstrap_cfg.llm_model if bootstrap_cfg else None)
+    elif bootstrap_cfg and bootstrap_cfg.queries:
+        queries = list(bootstrap_cfg.queries)
+        use_llm = _as_bool(use_llm_env) if use_llm_env is not None else bootstrap_cfg.use_llm
+        llm_model = llm_model_env or bootstrap_cfg.llm_model
+    else:
+        print(
+            "No bootstrap queries configured. Provide Q=\"your query\" to index manually.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not queries:
+        print("No queries available for indexing; exiting.", file=sys.stderr)
+        return 0
+
+    logger.info("Preparing embedding model for bootstrap (model=%s)", llm_model or embedder.model)
+    try:
+        status = embed_manager.ensure(llm_model)
+    except Exception as exc:  # pragma: no cover - network/ollama issues
+        logger.error("Failed to ensure embedding model: %s", exc)
+        return 1
+
+    if status.get("state") != "ready":
+        detail = status.get("detail") or status.get("error") or "embedding model unavailable"
+        logger.warning("Embedding model not ready; skipping bootstrap (%s)", detail)
+        return 0
+
+    active_model = status.get("model") or embed_manager.active_model
+    if active_model:
+        embedder.set_model(str(active_model))
+        logger.info("Using embedding model '%s'", active_model)
+
+    total_indexed = 0
+    for query in _iter_queries(queries):
+        try:
+            count = coldstart.build_index(query, use_llm=use_llm, llm_model=llm_model)
+        except Exception as exc:  # pragma: no cover - crawling is inherently flaky
+            logger.error("Failed to index query '%s': %s", query, exc)
+            continue
+        logger.info("Indexed %d pages for query: %s", count, query)
+        total_indexed += count
+
+    logger.info("Bootstrap complete. Total pages indexed: %d", total_indexed)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution script
+    sys.exit(main())

--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,11 @@ crawl:
   read_timeout: 30
   max_pages: 5
   sleep_seconds: 1.0
+bootstrap:
+  enabled: true
+  use_llm: true
+  llm_model: null
+  queries:
+    - "top news in the USA"
+    - "how to build a python library"
+    - "latest breakthroughs in artificial intelligence"

--- a/tests/engine/test_config.py
+++ b/tests/engine/test_config.py
@@ -57,3 +57,45 @@ def test_non_empty_env_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 
     assert cfg.index.persist_dir == config_path.parent / "custom/chroma"
     assert cfg.index.db_path == config_path.parent / "custom/index.duckdb"
+
+
+def test_bootstrap_section_parses(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+models:
+  llm_primary: bootstrap-primary
+  llm_fallback: bootstrap-fallback
+  embed: bootstrap-embed
+ollama:
+  base_url: http://localhost
+retrieval:
+  k: 2
+  min_hits: 1
+  similarity_threshold: 0.1
+index:
+  persist_dir: ./data/chroma
+  db_path: ./data/index.duckdb
+crawl:
+  user_agent: test-agent
+  request_timeout: 5
+  read_timeout: 5
+  max_pages: 3
+  sleep_seconds: 0.5
+bootstrap:
+  enabled: true
+  use_llm: false
+  llm_model: llama3
+  queries:
+    - first query
+    - second query
+""".strip()
+    )
+
+    cfg = EngineConfig.from_yaml(config_path)
+
+    assert cfg.bootstrap is not None
+    assert cfg.bootstrap.enabled is True
+    assert cfg.bootstrap.use_llm is False
+    assert cfg.bootstrap.llm_model == "llama3"
+    assert cfg.bootstrap.queries == ("first query", "second query")

--- a/tests/engine/test_vector_store.py
+++ b/tests/engine/test_vector_store.py
@@ -42,6 +42,26 @@ def test_vector_store_round_trip(tmp_path):
     assert retrieved.similarity >= 0.99
 
 
+def test_is_empty(tmp_path):
+    persist_dir = tmp_path / "chroma"
+    db_path = tmp_path / "index.duckdb"
+    store = VectorStore(persist_dir, db_path)
+
+    assert store.is_empty() is True
+
+    url = "https://example.com/bootstrap"
+    title = "Bootstrap"
+    etag = "W/\"67890\""
+    content = "Bootstrap content"
+    content_hash = _hash(content)
+    chunk = Chunk(text=content, start=0, end=len(content), token_count=3)
+    embedding = [0.2, 0.3, 0.4]
+
+    store.upsert(url, title, etag, content_hash, [chunk], [embedding])
+
+    assert store.is_empty() is False
+
+
 class RecordingCollection:
     def __init__(self) -> None:
         self.deleted: list[dict] = []


### PR DESCRIPTION
## Summary
- add a bootstrap configuration section and CLI helper to seed the cold-start index
- trigger background bootstrap runs on app startup and wire `make index` to the helper
- cover the new config and vector store helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a7fd619883218fcdf94d79b2147b