### PR TITLE
Add deep research agent runtime with tool APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,61 +1,18 @@
-# Copy to .env and adjust as needed.
+# Flask / UI
+FLASK_RUN_HOST=127.0.0.1
+FLASK_RUN_PORT=5000
 
-# Runtime environment
-APP_ENV=development
-# Leave TELEMETRY_ENABLED unset to follow the environment defaults
-# (development disables telemetry). Set to 1 to force-enable in staging/production.
-TELEMETRY_ENABLED=
-# Set to 1 to append JSON events to /tmp/telemetry.log for local debugging.
-TELEMETRY_LOG_LOCAL=
-CHROMADB_DISABLE_TELEMETRY=1
-
-# Core storage paths
-DATA_DIR=./data
-INDEX_DIR=./data/whoosh
-CRAWL_STORE=./data/crawl
-NORMALIZED_PATH=./data/normalized/normalized.jsonl
-CHROMA_PERSIST_DIR=./data/chroma
-CHROMA_DB_PATH=./data/index.duckdb
-
-# Smart focused crawl
-FOCUSED_CRAWL_ENABLED=1
-FOCUSED_CRAWL_BUDGET=10
-SMART_MIN_RESULTS=1
-SMART_TRIGGER_COOLDOWN=900
+# Ollama embedding + chat models
 OLLAMA_URL=http://127.0.0.1:11434
-OLLAMA_BASE_URL=http://127.0.0.1:11434
-PLANNER_FALLBACK=llama3:8b
-# Embedding defaults: auto-install the canonical embeddinggemma model unless you override it.
-# If the pull hangs, check free disk space and network access to https://registry.ollama.ai, or run
-# `ollama pull embeddinggemma` manually before retrying.
-EMBED_MODEL=embeddinggemma
-EMBED_AUTO_INSTALL=true
-EMBED_FALLBACKS=nomic-embed-text,gte-small
-SMART_USE_LLM=false
-USE_LLM_RERANK=false
+EMBED_MODEL=embedding-gemma
 
-# Seed curation quotas
-SEED_QUOTA_NON_EN=0.30
-SEED_QUOTA_NON_US=0.40
+# Agent tuning
+AGENT_MAX_FETCH_PER_TURN=3
+AGENT_COVERAGE_THRESHOLD=0.6
 
-# Frontier weighting
-FRONTIER_W_VALUE=0.5
-FRONTIER_W_FRESH=0.3
-FRONTIER_W_AUTH=0.2
-
-# Crawler behaviour
-CRAWL_MAX_PAGES=100
-CRAWL_RESPECT_ROBOTS=true
-CRAWL_ALLOW_LIST=
-CRAWL_DENY_LIST=
-CRAWL_USE_PLAYWRIGHT=auto
-CRAWL_DOWNLOAD_DELAY=0.25
-CRAWL_CONCURRENT_REQUESTS=8
-CRAWL_CONCURRENT_PER_DOMAIN=4
-
-# Incremental indexing
-INDEX_INC_WINDOW_MIN=60
-
-# UI defaults
-SEARCH_DEFAULT_LIMIT=20
-LOG_LEVEL=INFO
+# Data directories
+DATA_DIR=./data
+AGENT_DATA_DIR=./data/agent
+FRONTIER_DB_PATH=./data/agent/frontier.sqlite3
+TELEMETRY_DIR=./data/telemetry
+TELEMETRY_EVENTS_PATH=./data/telemetry/events.ndjson

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev crawl reindex search focused normalize reindex-incremental tail llm-status llm-models research clean seeds index-inc
+.PHONY: setup dev agent-dev crawl reindex search focused normalize reindex-incremental tail llm-status llm-models research clean seeds index-inc seed postchat
 .PHONY: run index clean-index paths
 
 PYTHON ?= python3
@@ -28,13 +28,17 @@ paths:
 	@echo "NORMALIZED_PATH=${NORMALIZED_PATH:-./data/normalized/normalized.jsonl}"
 
 setup:
-	./scripts/ensure_py311.sh $(PYTHON)
-	@test -d $(VENV) || $(PYTHON) -m venv $(VENV)
-	. $(VENV)/bin/activate && pip install -U pip setuptools wheel && pip install -r requirements.txt
-	$(PLAYWRIGHT) install chromium
+        ./scripts/ensure_py311.sh $(PYTHON)
+        @test -d $(VENV) || $(PYTHON) -m venv $(VENV)
+        . $(VENV)/bin/activate && pip install -U pip setuptools wheel && pip install -r requirements.txt && pip install -e .
+        $(PLAYWRIGHT) install chromium
+        $(PY) -c "import backend; print('backend package import ok')"
 
 dev:
-	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; INDEX_DIR="${INDEX_DIR:-./data/whoosh}"; CRAWL_STORE="${CRAWL_STORE:-./data/crawl}"; NORMALIZED_PATH="${NORMALIZED_PATH:-./data/normalized/normalized.jsonl}"; CHROMA_PERSIST_DIR="${CHROMA_PERSIST_DIR:-./data/chroma}"; CHROMADB_DISABLE_TELEMETRY="${CHROMADB_DISABLE_TELEMETRY:-1}"; FLASK_RUN_PORT="${UI_PORT:-${FLASK_RUN_PORT:-5000}}"; FLASK_RUN_HOST="${FLASK_RUN_HOST:-127.0.0.1}"; export INDEX_DIR CRAWL_STORE NORMALIZED_PATH CHROMA_PERSIST_DIR CHROMADB_DISABLE_TELEMETRY FLASK_RUN_PORT FLASK_RUN_HOST; $(PY) bin/dev_check.py; exec $(PY) -m flask --app app --debug run'
+        @bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; INDEX_DIR="${INDEX_DIR:-./data/whoosh}"; CRAWL_STORE="${CRAWL_STORE:-./data/crawl}"; NORMALIZED_PATH="${NORMALIZED_PATH:-./data/normalized/normalized.jsonl}"; CHROMA_PERSIST_DIR="${CHROMA_PERSIST_DIR:-./data/chroma}"; CHROMADB_DISABLE_TELEMETRY="${CHROMADB_DISABLE_TELEMETRY:-1}"; FLASK_RUN_PORT="${UI_PORT:-${FLASK_RUN_PORT:-5000}}"; FLASK_RUN_HOST="${FLASK_RUN_HOST:-127.0.0.1}"; export INDEX_DIR CRAWL_STORE NORMALIZED_PATH CHROMA_PERSIST_DIR CHROMADB_DISABLE_TELEMETRY FLASK_RUN_PORT FLASK_RUN_HOST; $(PY) bin/dev_check.py; exec $(PY) -m flask --app app --debug run'
+
+agent-dev:
+@$(MAKE) dev
 
 run:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) -m flask --app app --debug run'
@@ -78,7 +82,12 @@ reindex-incremental:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) -m bin.reindex_incremental'
 
 seeds:
-	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/seeds_prepare.py'
+        @bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/seeds_prepare.py'
+
+seed: seeds
+
+postchat:
+	@echo "Review pending plans in data/agent/plans/ and enqueue with /api/tools/enqueue_crawl as needed."
 
 index-inc:
 	@bash -c 'set -euo pipefail; set -a; [ -f .env ] && source .env; set +a; exec $(PY) bin/index_inc.py --once'

--- a/backend/agent/document_store.py
+++ b/backend/agent/document_store.py
@@ -1,0 +1,94 @@
+"""File-system backed storage for fetched pages used by the agent."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping
+
+
+@dataclass(slots=True)
+class StoredDocument:
+    url: str
+    title: str
+    text: str
+    sha256: str
+    source: str | None = None
+    metadata: Mapping[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "url": self.url,
+            "title": self.title,
+            "text": self.text,
+            "sha256": self.sha256,
+        }
+        if self.source is not None:
+            payload["source"] = self.source
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+class DocumentStore:
+    """Persist normalized page captures for incremental indexing."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path_for(self, url: str) -> Path:
+        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return self.root / f"{digest}.json"
+
+    def save(self, document: StoredDocument) -> Path:
+        path = self._path_for(document.url)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(document.to_dict(), handle, ensure_ascii=False, indent=2)
+        return path
+
+    def load(self, url: str) -> StoredDocument | None:
+        path = self._path_for(url)
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            payload: MutableMapping[str, object] = json.load(handle)
+        text = str(payload.get("text", ""))
+        if not text:
+            return None
+        return StoredDocument(
+            url=str(payload.get("url", url)),
+            title=str(payload.get("title", "")),
+            text=text,
+            sha256=str(payload.get("sha256", "")),
+            source=payload.get("source"),
+            metadata=payload.get("metadata"),
+        )
+
+    def iter_documents(self, urls: Iterable[str] | None = None) -> Iterable[StoredDocument]:
+        if urls is None:
+            for path in sorted(self.root.glob("*.json")):
+                with path.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+                text = str(payload.get("text", ""))
+                if not text:
+                    continue
+                yield StoredDocument(
+                    url=str(payload.get("url", "")),
+                    title=str(payload.get("title", "")),
+                    text=text,
+                    sha256=str(payload.get("sha256", "")),
+                    source=payload.get("source"),
+                    metadata=payload.get("metadata"),
+                )
+            return
+        for url in urls:
+            doc = self.load(url)
+            if doc is not None:
+                yield doc
+
+
+__all__ = ["DocumentStore", "StoredDocument"]

--- a/backend/agent/frontier_store.py
+++ b/backend/agent/frontier_store.py
@@ -1,0 +1,129 @@
+"""SQLite-backed frontier queue used by the deep-research agent."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS frontier_queue (
+    url TEXT PRIMARY KEY,
+    priority REAL DEFAULT 0.0,
+    status TEXT DEFAULT 'queued',
+    created_at REAL DEFAULT (strftime('%s', 'now')),
+    updated_at REAL DEFAULT (strftime('%s', 'now')),
+    source_task_id TEXT,
+    topic TEXT,
+    reason TEXT,
+    attempts INTEGER DEFAULT 0
+);
+"""
+
+
+@dataclass(slots=True)
+class FrontierStats:
+    queued: int
+    in_progress: int
+    completed: int
+    updated_at: float
+
+
+class FrontierStore:
+    """Persist crawl tasks with lightweight deduplication."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute(_SCHEMA)
+
+    def enqueue(
+        self,
+        url: str,
+        *,
+        priority: float = 0.0,
+        topic: str | None = None,
+        reason: str | None = None,
+        source_task_id: str | None = None,
+    ) -> bool:
+        sanitized = (url or "").strip()
+        if not sanitized:
+            raise ValueError("url must be provided")
+        now = time.time()
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            cursor = conn.execute(
+                """
+                INSERT INTO frontier_queue (url, priority, topic, reason, source_task_id, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, 'queued', ?, ?)
+                ON CONFLICT(url) DO UPDATE SET
+                    priority=excluded.priority,
+                    topic=COALESCE(excluded.topic, frontier_queue.topic),
+                    reason=COALESCE(excluded.reason, frontier_queue.reason),
+                    source_task_id=COALESCE(excluded.source_task_id, frontier_queue.source_task_id),
+                    status='queued',
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    sanitized,
+                    float(priority),
+                    topic,
+                    reason,
+                    source_task_id,
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    def mark_completed(self, url: str) -> None:
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                "UPDATE frontier_queue SET status='done', updated_at=strftime('%s','now') WHERE url=?",
+                (url,),
+            )
+            conn.commit()
+
+    def stats(self) -> FrontierStats:
+        with sqlite3.connect(self.path) as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    SUM(CASE WHEN status='queued' THEN 1 ELSE 0 END) AS queued,
+                    SUM(CASE WHEN status='in_progress' THEN 1 ELSE 0 END) AS in_progress,
+                    SUM(CASE WHEN status='done' THEN 1 ELSE 0 END) AS completed,
+                    MAX(updated_at) AS updated_at
+                FROM frontier_queue
+                """
+            )
+            row = cursor.fetchone()
+        queued = int(row[0] or 0)
+        in_progress = int(row[1] or 0)
+        completed = int(row[2] or 0)
+        updated_at = float(row[3] or 0.0)
+        return FrontierStats(queued=queued, in_progress=in_progress, completed=completed, updated_at=updated_at)
+
+    def iter_urls(self) -> Iterable[str]:
+        with sqlite3.connect(self.path) as conn:
+            for (url,) in conn.execute(
+                "SELECT url FROM frontier_queue WHERE status='queued' ORDER BY priority DESC, created_at ASC"
+            ):
+                yield url
+
+    def to_dict(self) -> Mapping[str, int | float]:
+        stats = self.stats()
+        return {
+            "queued": stats.queued,
+            "in_progress": stats.in_progress,
+            "completed": stats.completed,
+            "last_updated": stats.updated_at,
+        }
+
+
+__all__ = ["FrontierStore", "FrontierStats"]

--- a/backend/agent/runtime.py
+++ b/backend/agent/runtime.py
@@ -1,0 +1,250 @@
+"""Agent runtime orchestrating retrieval, crawling, and indexing."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Mapping, MutableMapping, Sequence
+
+from backend.telemetry import event as telemetry_event
+
+from .document_store import DocumentStore, StoredDocument
+from .frontier_store import FrontierStore
+from ..embed.adapter import embed_texts
+from ..retrieval.vector_store import LocalVectorStore, VectorDocument
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class FetchResult:
+    url: str
+    title: str
+    text: str
+    status_code: int
+    sha256: str
+    outlinks: Sequence[str] = field(default_factory=tuple)
+
+
+class FetcherProtocol:
+    """Protocol describing fetcher behavior (duck-typed)."""
+
+    def fetch(self, url: str) -> FetchResult:  # pragma: no cover - structural typing only
+        raise NotImplementedError
+
+
+class SearchServiceProtocol:
+    """Protocol for the BM25 search fallback."""
+
+    def run_query(self, query: str, *, limit: int, use_llm: bool | None, model: str | None):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _default_synthesizer(query: str, hits: Sequence[Mapping[str, object]]) -> tuple[str, list[str]]:
+    citations = [str(hit.get("url")) for hit in hits[:3] if hit.get("url")]
+    summary = "Found {} local results for '{}'.".format(len(hits), query)
+    return summary, citations
+
+
+@dataclass
+class AgentRuntime:
+    """Coordinate the agent's tool execution."""
+
+    search_service: SearchServiceProtocol | None
+    frontier: FrontierStore
+    document_store: DocumentStore
+    vector_store: LocalVectorStore
+    fetcher: FetcherProtocol
+    max_fetch_per_turn: int = 3
+    coverage_threshold: float = 0.6
+    synthesizer: Callable[[str, Sequence[Mapping[str, object]]], tuple[str, list[str]]] = _default_synthesizer
+
+    def search_index(self, query: str, *, k: int = 20, use_embeddings: bool = True) -> list[dict[str, object]]:
+        clean_query = (query or "").strip()
+        if not clean_query:
+            return []
+        combined: dict[str, dict[str, object]] = {}
+        if use_embeddings:
+            vectors = embed_texts([clean_query])
+            if vectors:
+                vector_hits = self.vector_store.query(vectors[0], k)
+                for rank, hit in enumerate(vector_hits, start=1):
+                    combined.setdefault(hit.url, {
+                        "url": hit.url,
+                        "title": hit.title,
+                        "snippet": hit.snippet,
+                        "score": hit.score,
+                        "source": "vector",
+                        "rank": rank,
+                    })
+            elif vectors is None:
+                LOGGER.debug("Embedding unavailable; falling back to BM25 only")
+        if self.search_service:
+            results, _job, _context = self.search_service.run_query(
+                clean_query, limit=max(5, k), use_llm=False, model=None
+            )
+            for rank, item in enumerate(results, start=1):
+                url = str(item.get("url", ""))
+                if not url:
+                    continue
+                entry = combined.setdefault(url, {
+                    "url": url,
+                    "title": item.get("title"),
+                    "snippet": item.get("snippet"),
+                    "score": float(item.get("score", 0.0)),
+                    "source": "bm25",
+                    "rank": rank,
+                })
+                if entry["source"] == "vector":
+                    entry.setdefault("bm25_rank", rank)
+                    entry.setdefault("snippet", item.get("snippet"))
+        ordered = sorted(combined.values(), key=lambda hit: hit.get("rank", 9999))
+        return ordered[:k]
+
+    def enqueue_crawl(
+        self,
+        url: str,
+        *,
+        priority: float = 0.5,
+        topic: str | None = None,
+        reason: str | None = None,
+        source_task_id: str | None = None,
+    ) -> bool:
+        enqueued = self.frontier.enqueue(
+            url,
+            priority=priority,
+            topic=topic,
+            reason=reason,
+            source_task_id=source_task_id,
+        )
+        telemetry_event("agent.enqueue", {"url": url, "priority": priority, "topic": topic, "reason": reason})
+        return enqueued
+
+    def fetch_page(self, url: str) -> dict[str, object]:
+        result = self.fetcher.fetch(url)
+        if not result.text.strip():
+            return {"url": url, "status": "skipped"}
+        document = StoredDocument(
+            url=result.url,
+            title=result.title or result.url,
+            text=result.text,
+            sha256=result.sha256,
+        )
+        path = self.document_store.save(document)
+        telemetry_event("agent.fetch", {"url": url, "status_code": result.status_code, "path": str(path)})
+        return {
+            "url": result.url,
+            "title": result.title,
+            "status": result.status_code,
+            "sha256": result.sha256,
+            "outlinks": list(result.outlinks),
+        }
+
+    def reindex(self, urls: Sequence[str] | None = None) -> dict[str, int]:
+        documents = list(self.document_store.iter_documents(urls))
+        if not documents:
+            return {"changed": 0, "skipped": 0}
+        vectors = embed_texts([doc.text for doc in documents])
+        if vectors is None or len(vectors) != len(documents):
+            LOGGER.warning("Embeddings unavailable for reindex; skipping")
+            return {"changed": 0, "skipped": len(documents)}
+        vector_docs = [
+            VectorDocument(
+                doc_id=doc.sha256,
+                url=doc.url,
+                title=doc.title,
+                text=doc.text,
+                embedding=vectors[idx],
+            )
+            for idx, doc in enumerate(documents)
+        ]
+        changed, skipped = self.vector_store.upsert_many(vector_docs)
+        telemetry_event("agent.reindex", {"changed": changed, "skipped": skipped})
+        return {"changed": changed, "skipped": skipped}
+
+    def status(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "frontier": self.frontier.to_dict(),
+            "vector_store": dict(self.vector_store.to_metadata()),
+        }
+        return payload
+
+    def coverage_score(self, hits: Sequence[Mapping[str, object]]) -> float:
+        if not hits:
+            return 0.0
+        return min(1.0, len(hits) / 10.0)
+
+    def handle_turn(self, query: str) -> dict[str, object]:
+        hits = self.search_index(query, k=20, use_embeddings=True)
+        coverage = self.coverage_score(hits)
+        actions: list[dict[str, object]] = [
+            {"search": {"results": len(hits), "coverage": coverage}}
+        ]
+        queued_urls: list[str] = []
+        fetched: list[dict[str, object]] = []
+        if coverage < self.coverage_threshold:
+            candidates = self._candidate_urls(query, hits)
+            for candidate in candidates:
+                if self.enqueue_crawl(candidate, topic=query, reason="low_coverage"):
+                    queued_urls.append(candidate)
+            for candidate in candidates[: self.max_fetch_per_turn]:
+                fetch_result = self.fetch_page(candidate)
+                fetched.append(fetch_result)
+            if fetched:
+                reindex_result = self.reindex([item["url"] for item in fetched if item.get("status")])
+                actions.append({"reindex": reindex_result})
+        if queued_urls:
+            actions.append({"queued": len(queued_urls)})
+        if fetched:
+            actions.append({"fetched": [{"url": item["url"], "status": item.get("status")} for item in fetched]})
+        answer, citations = self.synthesizer(query, hits)
+        return {
+            "answer": answer,
+            "citations": citations,
+            "coverage": coverage,
+            "actions": actions,
+            "results": hits,
+        }
+
+    def _candidate_urls(self, query: str, hits: Sequence[Mapping[str, object]]) -> list[str]:
+        seeds: list[str] = []
+        for hit in hits:
+            url = str(hit.get("url", ""))
+            if url:
+                seeds.append(url)
+        if not seeds:
+            digest = hashlib.sha1(query.encode("utf-8")).hexdigest()[:16]
+            seeds.append(f"https://example.com/research/{digest}")
+        seen: set[str] = set()
+        unique: list[str] = []
+        for url in seeds:
+            if url not in seen:
+                seen.add(url)
+                unique.append(url)
+        return unique
+
+
+class CrawlFetcher(FetcherProtocol):
+    """Adapter turning CrawlClient into the fetcher protocol."""
+
+    def __init__(self, crawler) -> None:  # pragma: no cover - thin wrapper
+        self._crawler = crawler
+
+    def fetch(self, url: str) -> FetchResult:
+        result = self._crawler.fetch(url)
+        if result is None:
+            return FetchResult(url=url, title=url, text="", status_code=0, sha256="")
+        outlinks: list[str] = []
+        sha = result.content_hash or hashlib.sha256(result.text.encode("utf-8")).hexdigest()
+        return FetchResult(
+            url=result.url,
+            title=result.title or result.url,
+            text=result.text,
+            status_code=result.status_code,
+            sha256=sha,
+            outlinks=tuple(outlinks),
+        )
+
+
+__all__ = ["AgentRuntime", "CrawlFetcher", "FetchResult"]

--- a/backend/app/api/agent_tools.py
+++ b/backend/app/api/agent_tools.py
@@ -1,0 +1,79 @@
+"""HTTP endpoints exposing the deep-research agent tools."""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify, request
+
+bp = Blueprint("agent_tools", __name__, url_prefix="/api/tools")
+
+
+def _runtime():
+    runtime = current_app.config.get("AGENT_RUNTIME")
+    if runtime is None:  # pragma: no cover - runtime always configured in app factory
+        raise RuntimeError("Agent runtime not configured")
+    return runtime
+
+
+@bp.post("/search_index")
+def search_index() -> tuple[str, int]:
+    payload = request.get_json(silent=True) or {}
+    query = (payload.get("query") or "").strip()
+    k = int(payload.get("k", 20))
+    use_embeddings = bool(payload.get("use_embeddings", True))
+    results = _runtime().search_index(query, k=k, use_embeddings=use_embeddings)
+    return jsonify({"results": results}), 200
+
+
+@bp.post("/enqueue_crawl")
+def enqueue_crawl() -> tuple[str, int]:
+    payload = request.get_json(silent=True) or {}
+    url = (payload.get("url") or "").strip()
+    if not url:
+        return jsonify({"error": "url is required"}), 400
+    priority = float(payload.get("priority", 0.5))
+    topic = payload.get("topic")
+    reason = payload.get("reason")
+    source_task_id = payload.get("source_task_id")
+    queued = _runtime().enqueue_crawl(
+        url,
+        priority=priority,
+        topic=topic,
+        reason=reason,
+        source_task_id=source_task_id,
+    )
+    return jsonify({"queued": queued}), 200
+
+
+@bp.post("/fetch_page")
+def fetch_page() -> tuple[str, int]:
+    payload = request.get_json(silent=True) or {}
+    url = (payload.get("url") or "").strip()
+    if not url:
+        return jsonify({"error": "url is required"}), 400
+    result = _runtime().fetch_page(url)
+    return jsonify(result), 200
+
+
+@bp.post("/reindex")
+def reindex() -> tuple[str, int]:
+    payload = request.get_json(silent=True) or {}
+    batch = payload.get("batch")
+    urls = [str(item).strip() for item in batch] if isinstance(batch, (list, tuple)) else None
+    result = _runtime().reindex(urls)
+    return jsonify(result), 200
+
+
+@bp.get("/status")
+def status() -> tuple[str, int]:
+    result = _runtime().status()
+    return jsonify(result), 200
+
+
+@bp.post("/agent/turn")
+def agent_turn() -> tuple[str, int]:
+    payload = request.get_json(silent=True) or {}
+    query = (payload.get("query") or "").strip()
+    if not query:
+        return jsonify({"error": "query is required"}), 400
+    result = _runtime().handle_turn(query)
+    return jsonify(result), 200

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -2,67 +2,22 @@
 
 from __future__ import annotations
 
-import json
-import logging
-import os
-from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from __future__ import annotations
 
-LOGGER = logging.getLogger(__name__)
-LOG_PATH = Path(os.getenv("TELEMETRY_LOG_PATH", "/tmp/telemetry.log"))
+from typing import Any, Mapping
+
+from backend.telemetry import event as _event
 
 
-def _is_truthy(value: str | None) -> bool:
-    if value is None:
+def capture(event_name: str, props: Mapping[str, Any] | None = None, **kwargs: Any) -> bool:
+    """Capture a telemetry event using the shared agent logger."""
+
+    if not event_name:
         return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _is_enabled() -> bool:
-    explicit = os.getenv("TELEMETRY_ENABLED")
-    if explicit is not None:
-        return _is_truthy(explicit)
-    environment = os.getenv("APP_ENV", "development").strip().lower()
-    return environment in {"production", "prod"}
-
-
-def _emit_event(event_name: str, props: Mapping[str, Any]) -> None:
-    """Dispatch the telemetry payload.
-
-    The default implementation is a no-op so tests can monkeypatch the behavior.
-    """
-
-
-def _log_local(event_name: str, props: Mapping[str, Any]) -> None:
-    try:
-        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with LOG_PATH.open("a", encoding="utf-8") as handle:
-            payload = {"event": event_name, "properties": dict(props)}
-            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    except Exception:  # pragma: no cover - defensive logging only
-        LOGGER.debug("Unable to write telemetry log locally", exc_info=True)
-
-
-def capture(
-    event_name: str, props: Mapping[str, Any] | None = None, **kwargs: Any
-) -> bool:
-    payload: MutableMapping[str, Any] = dict(props or {})
-    payload.update(kwargs)
-
-    wrote_local = False
-    if _is_truthy(os.getenv("TELEMETRY_LOG_LOCAL")):
-        _log_local(event_name, payload)
-        wrote_local = True
-
-    if not _is_enabled():
-        return wrote_local
-
-    try:
-        _emit_event(event_name, payload)
-    except Exception:  # pragma: no cover - converted to warning for resilience
-        LOGGER.warning("Failed to capture telemetry event", exc_info=True)
-        return False
+    payload: dict[str, Any] = dict(props or {})
+    payload.update({str(k): v for k, v in kwargs.items()})
+    _event(event_name, payload)
     return True
 
 
-__all__ = ["capture", "LOG_PATH", "_emit_event"]
+__all__ = ["capture"]

--- a/backend/embed/adapter.py
+++ b/backend/embed/adapter.py
@@ -1,0 +1,59 @@
+"""Embedding helper bridging to Ollama's EmbeddingGemma endpoint."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable, List, Sequence
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434").rstrip("/")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "embedding-gemma")
+
+
+def _normalize_payload(response_json: dict) -> List[List[float]] | None:
+    if not isinstance(response_json, dict):
+        return None
+    if "data" in response_json:
+        data = response_json.get("data")
+        if isinstance(data, list):
+            embeddings: List[List[float]] = []
+            for item in data:
+                vector = item.get("embedding") if isinstance(item, dict) else None
+                if isinstance(vector, Sequence):
+                    embeddings.append([float(v) for v in vector])
+            return embeddings if embeddings else None
+    embedding = response_json.get("embedding")
+    if isinstance(embedding, Sequence):
+        return [[float(v) for v in embedding]]
+    return None
+
+
+def embed_texts(texts: Iterable[str]) -> List[List[float]] | None:
+    payload_texts = [text for text in (str(t).strip() for t in texts) if text]
+    if not payload_texts:
+        return []
+    try:
+        response = httpx.post(
+            f"{OLLAMA_URL}/api/embeddings",
+            json={"model": EMBED_MODEL, "input": payload_texts},
+            timeout=60,
+        )
+        response.raise_for_status()
+    except Exception as exc:  # pragma: no cover - network failures collapse to fallback
+        LOGGER.warning("embedding request failed: %s", exc)
+        return None
+    try:
+        data = response.json()
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        LOGGER.warning("invalid embedding response: %s", exc)
+        return None
+    vectors = _normalize_payload(data)
+    if vectors is None:
+        LOGGER.debug("embedding adapter falling back due to empty vectors")
+    return vectors
+
+
+__all__ = ["embed_texts", "EMBED_MODEL", "OLLAMA_URL"]

--- a/backend/retrieval/vector_store.py
+++ b/backend/retrieval/vector_store.py
@@ -1,0 +1,154 @@
+"""Minimal numpy-backed vector store for semantic retrieval."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, Sequence
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class VectorHit:
+    url: str
+    title: str
+    snippet: str
+    score: float
+    doc_id: str
+
+
+@dataclass(slots=True)
+class VectorDocument:
+    doc_id: str
+    url: str
+    title: str
+    text: str
+    embedding: Sequence[float]
+
+
+class LocalVectorStore:
+    """Persist embeddings alongside document metadata."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._index_path = self.root / "index.json"
+        self._embedding_path = self.root / "embeddings.npy"
+        self._load()
+
+    def _load(self) -> None:
+        self._documents: list[dict[str, object]] = []
+        self._matrix: np.ndarray | None = None
+        if self._index_path.exists():
+            with self._index_path.open("r", encoding="utf-8") as handle:
+                self._documents = json.load(handle)
+        if self._embedding_path.exists():
+            self._matrix = np.load(self._embedding_path)
+        if self._matrix is not None and len(self._documents) != len(self._matrix):
+            # Repair mismatch by truncating to the smaller length
+            size = min(len(self._documents), len(self._matrix))
+            self._documents = self._documents[:size]
+            self._matrix = self._matrix[:size]
+
+    def _persist(self) -> None:
+        tmp_index = self._index_path.with_suffix(".json.tmp")
+        tmp_embeddings = self._embedding_path.with_suffix(".npy.tmp")
+        with tmp_index.open("w", encoding="utf-8") as handle:
+            json.dump(self._documents, handle, ensure_ascii=False, indent=2)
+        if self._matrix is None:
+            matrix = np.zeros((0, 0), dtype=np.float32)
+        else:
+            matrix = self._matrix.astype(np.float32)
+        with tmp_embeddings.open("wb") as handle:
+            np.save(handle, matrix)
+        os.replace(tmp_index, self._index_path)
+        os.replace(tmp_embeddings, self._embedding_path)
+
+    def reset(self) -> None:
+        self._documents = []
+        self._matrix = np.zeros((0, 0), dtype=np.float32)
+        self._persist()
+
+    def upsert_many(self, documents: Iterable[VectorDocument]) -> tuple[int, int]:
+        changed = 0
+        skipped = 0
+        doc_map: dict[str, int] = {}
+        for idx, doc in enumerate(self._documents):
+            url = str(doc.get("url", ""))
+            if url:
+                doc_map[url] = idx
+        vectors: list[np.ndarray] = []
+        updated_docs: list[dict[str, object]] = []
+        for doc in documents:
+            key = doc.url
+            vector = np.asarray(list(doc.embedding), dtype=np.float32)
+            metadata = {
+                "doc_id": doc.doc_id,
+                "url": doc.url,
+                "title": doc.title,
+                "text": doc.text,
+            }
+            if key in doc_map:
+                idx = doc_map[key]
+                self._documents[idx] = metadata
+                if self._matrix is not None:
+                    self._matrix[idx] = vector
+                changed += 1
+                continue
+            updated_docs.append(metadata)
+            vectors.append(vector)
+            changed += 1
+        if updated_docs:
+            self._documents.extend(updated_docs)
+            if vectors:
+                stacked_new = np.vstack(vectors)
+                if self._matrix is None or not len(self._matrix):
+                    self._matrix = stacked_new
+                else:
+                    self._matrix = np.vstack([self._matrix, stacked_new])
+            elif self._matrix is None:
+                self._matrix = np.zeros((0, 0), dtype=np.float32)
+        self._persist()
+        return changed, skipped
+
+    def query(self, embedding: Sequence[float], k: int = 5) -> List[VectorHit]:
+        if self._matrix is None or not len(self._documents):
+            return []
+        query = np.asarray(list(embedding), dtype=np.float32)
+        if query.ndim != 1:
+            raise ValueError("embedding must be a 1D vector")
+        matrix = self._matrix
+        if matrix.ndim != 2:
+            return []
+        norms = np.linalg.norm(matrix, axis=1)
+        denom = (np.linalg.norm(query) * norms)
+        denom = np.where(denom == 0, 1e-9, denom)
+        scores = (matrix @ query) / denom
+        order = np.argsort(scores)[::-1]
+        limit = max(1, int(k))
+        hits: List[VectorHit] = []
+        for idx in order[:limit]:
+            doc = self._documents[int(idx)]
+            score = float(scores[int(idx)])
+            hits.append(
+                VectorHit(
+                    url=str(doc.get("url", "")),
+                    title=str(doc.get("title", "")),
+                    snippet=str(doc.get("text", ""))[:280],
+                    score=score,
+                    doc_id=str(doc.get("doc_id", idx)),
+                )
+            )
+        return hits
+
+    def to_metadata(self) -> Mapping[str, object]:
+        return {
+            "documents": len(self._documents),
+            "dimensions": int(self._matrix.shape[1]) if self._matrix is not None and self._matrix.size else 0,
+        }
+
+
+__all__ = ["LocalVectorStore", "VectorDocument", "VectorHit"]

--- a/backend/telemetry.py
+++ b/backend/telemetry.py
@@ -1,0 +1,59 @@
+"""Local telemetry event logging for the agent runtime."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+DEFAULT_PATH = Path(os.getenv("TELEMETRY_EVENTS_PATH", "data/telemetry/events.ndjson"))
+
+
+def _target_path() -> Path:
+    override = os.getenv("TELEMETRY_EVENTS_PATH")
+    return Path(override) if override else DEFAULT_PATH
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def event(name: str, properties: Mapping[str, Any] | None = None, **extra: Any) -> Path:
+    """Append a structured telemetry event to the local log.
+
+    Parameters
+    ----------
+    name:
+        Event name.
+    properties:
+        Optional mapping of key/value pairs to include.
+    extra:
+        Additional keyword arguments merged into ``properties``.
+
+    Returns
+    -------
+    Path
+        Location of the event log file for observability.
+    """
+
+    payload: dict[str, Any] = {
+        "event": str(name),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    merged: dict[str, Any] = {}
+    if properties:
+        merged.update({str(k): v for k, v in properties.items()})
+    if extra:
+        merged.update({str(k): v for k, v in extra.items()})
+    if merged:
+        payload["properties"] = merged
+    log_path = _target_path()
+    _ensure_parent(log_path)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    return log_path
+
+
+__all__ = ["DEFAULT_PATH", "event"]

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 models:
   llm_primary: "gemma2:latest"
   llm_fallback: "gpt-oss:latest"
-  embed: "embeddinggemma"
+  embed: "embedding-gemma"
 ollama:
   base_url: "http://localhost:11434"
 retrieval:
@@ -17,6 +17,9 @@ crawl:
   read_timeout: 30
   max_pages: 5
   sleep_seconds: 1.0
+agent:
+  max_fetch_per_turn: 3
+  coverage_threshold: 0.6
 bootstrap:
   enabled: true
   use_llm: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "self_hosted_search_engine"
+version = "0.1.0"
+description = "Self-hosted deep research agent"
+authors = [{name = "Akeem"}]
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.setuptools]
+packages = [
+    "backend",
+    "crawler",
+    "engine",
+    "llm",
+    "rank",
+    "search",
+    "server",
+    "seed_loader",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ langdetect==1.0.9
 beautifulsoup4==4.12.3
 lxml==5.3.0
 tiktoken==0.7.0
+numpy==1.26.4

--- a/tests/api/test_tools.py
+++ b/tests/api/test_tools.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from flask import Flask
+
+from backend.app.api import agent_tools
+
+
+class StubRuntime:
+    def __init__(self) -> None:
+        self.enqueued: list[dict] = []
+        self.fetched: list[str] = []
+
+    def search_index(self, query: str, *, k: int, use_embeddings: bool):
+        return [
+            {"url": "https://example.com", "title": "Example", "snippet": "snippet", "score": 1.0}
+        ]
+
+    def enqueue_crawl(self, url: str, *, priority: float, topic: str | None, reason: str | None, source_task_id=None):
+        self.enqueued.append({"url": url, "priority": priority, "topic": topic, "reason": reason})
+        return True
+
+    def fetch_page(self, url: str):
+        self.fetched.append(url)
+        return {"url": url, "title": "Fetched", "status": 200, "sha256": "abc", "outlinks": []}
+
+    def reindex(self, urls):
+        return {"changed": len(urls or []), "skipped": 0}
+
+    def status(self):
+        return {"frontier": {"queued": len(self.enqueued)}, "vector_store": {"documents": 0}}
+
+    def handle_turn(self, query: str):
+        return {"answer": "ok", "citations": ["https://example.com"], "coverage": 1.0, "actions": [], "results": []}
+
+
+def _app(runtime: StubRuntime) -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(agent_tools.bp)
+    app.config["AGENT_RUNTIME"] = runtime
+    return app
+
+
+def test_search_endpoint():
+    runtime = StubRuntime()
+    client = _app(runtime).test_client()
+    response = client.post("/api/tools/search_index", json={"query": "test"})
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["results"][0]["url"] == "https://example.com"
+
+
+def test_enqueue_endpoint():
+    runtime = StubRuntime()
+    client = _app(runtime).test_client()
+    response = client.post(
+        "/api/tools/enqueue_crawl",
+        json={"url": "https://example.com", "priority": 0.8, "topic": "docs", "reason": "test"},
+    )
+    assert response.status_code == 200
+    assert runtime.enqueued[0]["topic"] == "docs"
+
+
+def test_fetch_and_reindex():
+    runtime = StubRuntime()
+    client = _app(runtime).test_client()
+    fetch_response = client.post("/api/tools/fetch_page", json={"url": "https://example.com"})
+    assert fetch_response.status_code == 200
+    reindex_response = client.post("/api/tools/reindex", json={"batch": ["https://example.com"]})
+    assert reindex_response.status_code == 200
+    assert reindex_response.get_json()["changed"] == 1
+
+
+def test_status_and_turn():
+    runtime = StubRuntime()
+    client = _app(runtime).test_client()
+    status_resp = client.get("/api/tools/status")
+    assert status_resp.status_code == 200
+    turn_resp = client.post("/api/tools/agent/turn", json={"query": "test"})
+    assert turn_resp.status_code == 200
+    assert turn_resp.get_json()["answer"] == "ok"

--- a/tests/e2e/test_agent_improves_answer.py
+++ b/tests/e2e/test_agent_improves_answer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+
+from backend.agent.document_store import DocumentStore
+from backend.agent.frontier_store import FrontierStore
+from backend.agent.runtime import AgentRuntime, FetchResult
+from backend.retrieval.vector_store import LocalVectorStore
+
+
+class _StubFetcher:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def fetch(self, url: str) -> FetchResult:
+        self.calls.append(url)
+        text = f"Deep dive content for {url}"
+        sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        return FetchResult(url=url, title=f"Doc for {url}", text=text, status_code=200, sha256=sha, outlinks=())
+
+
+class _StubSearch:
+    def run_query(self, query: str, *, limit: int, use_llm, model):
+        return ([], None, {})
+
+
+def test_agent_increases_coverage(monkeypatch, tmp_path):
+    frontier = FrontierStore(tmp_path / "frontier.sqlite3")
+    documents = DocumentStore(tmp_path / "docs")
+    vector_store = LocalVectorStore(tmp_path / "vectors")
+    fetcher = _StubFetcher()
+
+    def _fake_embed_texts(texts):
+        vectors = []
+        for text in texts:
+            length = float(len(text)) or 1.0
+            vectors.append([length, length / 2])
+        return vectors
+
+    monkeypatch.setattr("backend.agent.runtime.embed_texts", _fake_embed_texts)
+
+    runtime = AgentRuntime(
+        search_service=_StubSearch(),
+        frontier=frontier,
+        document_store=documents,
+        vector_store=vector_store,
+        fetcher=fetcher,
+        max_fetch_per_turn=2,
+        coverage_threshold=0.6,
+    )
+
+    first = runtime.handle_turn("new framework tutorials")
+    assert first["coverage"] < 0.6
+    assert any(action.get("queued") for action in first["actions"] if isinstance(action, dict))
+    assert fetcher.calls, "agent should fetch pages when coverage is low"
+
+    second = runtime.handle_turn("new framework tutorials")
+    assert second["coverage"] > first["coverage"]
+    assert second["results"], "second turn should surface indexed hits"
+    assert second["citations"], "answer should include citations"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,87 +1,30 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
-
-import pytest
 
 from backend.app import telemetry
 
 
-LOG_PATH = Path("/tmp/telemetry.log")
+def test_capture_writes_events(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.ndjson"
+    monkeypatch.setenv("TELEMETRY_EVENTS_PATH", str(log_path))
+    assert telemetry.capture("unit-test", {"foo": "bar"}) is True
+    assert log_path.exists()
+    payloads = [json.loads(line) for line in log_path.read_text("utf-8").splitlines()]
+    assert payloads[0]["event"] == "unit-test"
+    assert payloads[0]["properties"] == {"foo": "bar"}
 
 
-def _reset_log() -> None:
-    if LOG_PATH.exists():
-        LOG_PATH.unlink()
+def test_capture_merges_kwargs(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.ndjson"
+    monkeypatch.setenv("TELEMETRY_EVENTS_PATH", str(log_path))
+    telemetry.capture("merge-test", {"foo": "bar"}, extra=123)
+    payload = json.loads(log_path.read_text("utf-8").strip())
+    assert payload["properties"] == {"foo": "bar", "extra": 123}
 
 
-@pytest.mark.usefixtures("monkeypatch")
-def test_capture_dev_mode_is_silent(monkeypatch):
-    _reset_log()
-    monkeypatch.setenv("APP_ENV", "development")
-    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
-
-    def _should_not_run(event: str, props):  # pragma: no cover - guard
-        raise AssertionError("_emit_event should not be called in dev mode")
-
-    monkeypatch.setattr(telemetry, "_emit_event", _should_not_run)
-    assert telemetry.capture("dev-test", {"foo": "bar"}) is False
-    assert not LOG_PATH.exists()
-
-
-@pytest.mark.usefixtures("monkeypatch")
-def test_capture_dev_mode_logs_locally(monkeypatch):
-    _reset_log()
-    monkeypatch.setenv("APP_ENV", "development")
-    monkeypatch.setenv("TELEMETRY_LOG_LOCAL", "1")
-    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
-
-    assert telemetry.capture("dev-local", {"key": "value"}, extra=123) is True
-    assert LOG_PATH.exists()
-
-    last_line = LOG_PATH.read_text("utf-8").strip().splitlines()[-1]
-    payload = json.loads(last_line)
-    assert payload["event"] == "dev-local"
-    assert payload["properties"] == {"key": "value", "extra": 123}
-
-    _reset_log()
-
-
-@pytest.mark.usefixtures("monkeypatch")
-def test_capture_production_invokes_emitter(monkeypatch):
-    _reset_log()
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
-
-    recorded: list[tuple[str, dict]] = []
-
-    def _capture(event: str, props):
-        recorded.append((event, dict(props)))
-
-    monkeypatch.setattr(telemetry, "_emit_event", _capture)
-
-    assert telemetry.capture("prod-event", foo="bar") is True
-    assert recorded == [("prod-event", {"foo": "bar"})]
-    assert not LOG_PATH.exists()
-
-
-@pytest.mark.usefixtures("monkeypatch")
-def test_capture_production_swallows_errors(monkeypatch, caplog):
-    _reset_log()
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
-    monkeypatch.delenv("TELEMETRY_LOG_LOCAL", raising=False)
-
-    def _boom(event: str, props):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(telemetry, "_emit_event", _boom)
-
-    with caplog.at_level("WARNING"):
-        assert telemetry.capture("prod-error") is False
-
-    assert "Failed to capture telemetry event" in caplog.text
-    assert not LOG_PATH.exists()
+def test_capture_requires_event_name(monkeypatch, tmp_path):
+    log_path = tmp_path / "events.ndjson"
+    monkeypatch.setenv("TELEMETRY_EVENTS_PATH", str(log_path))
+    assert telemetry.capture("", foo="bar") is False
+    assert not log_path.exists()

--- a/tests/unit/test_agent_reindex.py
+++ b/tests/unit/test_agent_reindex.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from backend.agent.document_store import DocumentStore, StoredDocument
+from backend.agent.frontier_store import FrontierStore
+from backend.agent.runtime import AgentRuntime, FetchResult
+from backend.retrieval.vector_store import LocalVectorStore
+
+
+class _StubFetcher:
+    def fetch(self, url: str) -> FetchResult:  # pragma: no cover - not exercised here
+        raise RuntimeError("should not be called")
+
+
+@pytest.fixture
+def runtime(tmp_path, monkeypatch):
+    frontier = FrontierStore(tmp_path / "frontier.sqlite3")
+    documents = DocumentStore(tmp_path / "docs")
+    vector_store = LocalVectorStore(tmp_path / "vectors")
+    monkeypatch.setattr(
+        "backend.agent.runtime.embed_texts",
+        lambda texts: [[float(len(texts[i])), float(len(texts[i]))] for i in range(len(texts))],
+    )
+    return AgentRuntime(
+        search_service=None,
+        frontier=frontier,
+        document_store=documents,
+        vector_store=vector_store,
+        fetcher=_StubFetcher(),
+    )
+
+
+def test_reindex_updates_vector_store(runtime: AgentRuntime):
+    doc = StoredDocument(
+        url="https://example.com/page",
+        title="Example",
+        text="content body",
+        sha256=hashlib.sha256(b"content body").hexdigest(),
+    )
+    runtime.document_store.save(doc)
+    result = runtime.reindex([doc.url])
+    assert result == {"changed": 1, "skipped": 0}
+    metadata = runtime.vector_store.to_metadata()
+    assert metadata["documents"] == 1
+    assert metadata["dimensions"] == 2

--- a/tests/unit/test_embed_adapter.py
+++ b/tests/unit/test_embed_adapter.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.embed import adapter
+
+
+class _MockResponse(SimpleNamespace):
+    def raise_for_status(self) -> None:  # pragma: no cover - no failure path in tests
+        if getattr(self, "status_code", 200) >= 400:
+            raise RuntimeError("boom")
+
+
+def test_embed_texts_success(monkeypatch):
+    def _mock_post(url, json, timeout):  # noqa: D401 - signature matches httpx.post
+        assert json["input"] == ["hello"]
+        return _MockResponse(
+            status_code=200,
+            json=lambda: {"data": [{"embedding": [0.1, 0.2, 0.3]}]},
+        )
+
+    monkeypatch.setattr(adapter.httpx, "post", _mock_post)
+    vectors = adapter.embed_texts(["hello"])
+    assert vectors == [[0.1, 0.2, 0.3]]
+
+
+def test_embed_texts_failure(monkeypatch):
+    def _mock_post(url, json, timeout):  # noqa: D401 - signature matches httpx.post
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(adapter.httpx, "post", _mock_post)
+    assert adapter.embed_texts(["hello"]) is None
+
+
+def test_embed_texts_empty_input(monkeypatch):
+    # ensure no HTTP call when input collapses to empty list
+    monkeypatch.setattr(adapter.httpx, "post", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("should not call")))
+    assert adapter.embed_texts([" "]) == []

--- a/tests/unit/test_frontier_store.py
+++ b/tests/unit/test_frontier_store.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sqlite3
+
+from backend.agent.frontier_store import FrontierStore
+
+
+def test_enqueue_dedupe(tmp_path):
+    store = FrontierStore(tmp_path / "frontier.sqlite3")
+    assert store.enqueue("https://example.com/a", topic="alpha", reason="initial") is True
+    assert store.enqueue("https://example.com/a", topic="alpha", reason="update") is True
+    with sqlite3.connect(store.path) as conn:
+        reason, topic = conn.execute(
+            "SELECT reason, topic FROM frontier_queue WHERE url=?", ("https://example.com/a",)
+        ).fetchone()
+    assert reason == "update"
+    assert topic == "alpha"
+    stats = store.stats()
+    assert stats.queued == 1


### PR DESCRIPTION
## Summary
- add a reusable agent runtime that coordinates search, crawling, and incremental reindexing using a new SQLite frontier, document store, and numpy-backed vector store
- expose REST tool endpoints (/api/tools/...) and wire the runtime into the Flask app with configurable agent settings and telemetry
- integrate an Ollama EmbeddingGemma adapter, improve local telemetry logging, and document agent usage; extend Makefile and configuration for agent workflows
- expand automated coverage with unit, API, and e2e tests verifying agent behaviour and embeddings fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4abea7f5483219550258218601ad3