### PR TITLE
feat: surface search results alongside chat

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -65,6 +65,7 @@ Set `NEXT_PUBLIC_API_BASE_URL` to the live backend URL before building if the AP
 
 ## Features snapshot
 
+- Unified omnibox workflow: keyword queries call `/api/search` and render side-by-side results with quick "Ask agent" escalation into chat.
 - Split pane layout with in-app browser preview, omnibox, and copilot chat
 - Streaming chat responses from `/api/chat` with inline action cards (crawl, index, seeds)
 - Drag & drop URLs into the crawl queue and highlight capture with manual approvals
@@ -82,3 +83,14 @@ The Crawl Manager widget now persists entries through the seed registry API:
 Agent-approved crawl actions also persist new seeds through the same API helpers so manual edits and automated approvals stay in sync.
 
 For backend configuration and deeper agent controls, see the repository root `README`.
+
+## Search and chat interplay
+
+The omnibox now routes non-URL submissions through the local semantic index:
+
+1. Press Enter on a keyword and the UI issues `GET /api/search?q=...` via the new `searchIndex` helper.
+2. Results, confidence, and crawl status appear in the Search panel beside the preview.
+3. Use the **Ask agent** button to send the same query to `/api/chat` when you need reasoning or follow-up actions.
+4. If the search triggers a focused crawl, progress is reflected both in the panel and the Agent Ops tab.
+
+Paste an absolute URL at any time to jump directly into the preview pane without triggering search.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,12 +8,16 @@
       "name": "copilot-frontend",
       "version": "0.0.0",
       "devDependencies": {
+        "@radix-ui/react-progress": "^1.0.3",
+        "@radix-ui/react-scroll-area": "^1.0.5",
+        "@radix-ui/react-slot": "^1.0.2",
         "@tailwindcss/postcss": "^4.1.13",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.3.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.2.74",
         "@types/react-dom": "^18.2.25",
+        "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "jsdom": "^24.0.0",
@@ -674,6 +678,251 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.0.3.tgz",
+      "integrity": "sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1790,6 +2039,29 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
+    "node_modules/class-variance-authority/node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/clsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,12 +8,16 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@radix-ui/react-progress": "^1.0.3",
+    "@radix-ui/react-scroll-area": "^1.0.5",
+    "@radix-ui/react-slot": "^1.0.2",
     "@tailwindcss/postcss": "^4.1.13",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18.2.25",
+    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "jsdom": "^24.0.0",

--- a/frontend/src/components/__tests__/search-results-panel.test.tsx
+++ b/frontend/src/components/__tests__/search-results-panel.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { SearchResultsPanel } from "@/components/search-results-panel";
+import type { SearchHit } from "@/lib/types";
+
+describe("SearchResultsPanel", () => {
+  const sampleHits: SearchHit[] = [
+    {
+      id: "1",
+      title: "Example Result",
+      url: "https://example.com",
+      snippet: "Example snippet",
+      score: 0.42,
+      blendedScore: 0.58,
+      lang: "en",
+    },
+  ];
+
+  it("renders search hits when available", () => {
+    const onOpenHit = vi.fn();
+    render(
+      <SearchResultsPanel
+        query="example"
+        hits={sampleHits}
+        status="ok"
+        isLoading={false}
+        error={null}
+        detail={null}
+        onOpenHit={onOpenHit}
+        currentUrl={null}
+      />
+    );
+
+    expect(screen.getByText("Example Result")).toBeInTheDocument();
+    expect(screen.getByText(/Example snippet/)).toBeInTheDocument();
+  });
+
+  it("shows placeholder when idle", () => {
+    render(
+      <SearchResultsPanel
+        query=""
+        hits={[]}
+        status="idle"
+        isLoading={false}
+        error={null}
+        detail={null}
+        onOpenHit={() => {}}
+        currentUrl={null}
+      />
+    );
+
+    expect(screen.getByText(/Enter a keyword/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/search-results-panel.tsx
+++ b/frontend/src/components/search-results-panel.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { AlertTriangle, ArrowUpRight, Loader2, RefreshCcw, Search as SearchIcon } from "lucide-react";
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { SearchHit } from "@/lib/types";
+
+const LOADING_PLACEHOLDERS = [0, 1, 2, 3];
+
+type SearchResultsStatus = "idle" | "loading" | "ok" | "warming" | "focused_crawl_running" | "error";
+
+interface SearchResultsPanelProps {
+  className?: string;
+  query: string;
+  hits: SearchHit[];
+  status: SearchResultsStatus;
+  isLoading: boolean;
+  error?: string | null;
+  detail?: string | null;
+  onOpenHit: (url: string) => void;
+  onAskAgent?: (query: string) => void;
+  onRefresh?: () => void;
+  currentUrl?: string | null;
+  confidence?: number | null;
+  llmUsed?: boolean;
+  triggerReason?: string | null;
+  seedCount?: number | null;
+  jobId?: string | null;
+  lastFetchedAt?: string | null;
+  actionLabel?: string | null;
+  code?: string | null;
+  candidates?: Array<Record<string, unknown>>;
+}
+
+function formatConfidence(confidence: number | null | undefined): number | null {
+  if (typeof confidence !== "number" || Number.isNaN(confidence)) {
+    return null;
+  }
+  return Math.max(0, Math.min(100, Math.round(confidence * 100)));
+}
+
+function normalizeReason(reason: string | null | undefined): string | null {
+  if (!reason) return null;
+  return reason.replace(/_/g, " ");
+}
+
+export function SearchResultsPanel({
+  className,
+  query,
+  hits,
+  status,
+  isLoading,
+  error,
+  detail,
+  onOpenHit,
+  onAskAgent,
+  onRefresh,
+  currentUrl,
+  confidence,
+  llmUsed,
+  triggerReason,
+  seedCount,
+  jobId,
+  lastFetchedAt,
+  actionLabel,
+  code,
+  candidates,
+}: SearchResultsPanelProps) {
+  const normalizedConfidence = useMemo(() => formatConfidence(confidence), [confidence]);
+  const triggerLabel = useMemo(() => normalizeReason(triggerReason), [triggerReason]);
+  const hasQuery = query.trim().length > 0;
+
+  const statusBadge = useMemo(() => {
+    if (status === "loading") {
+      return (
+        <Badge variant="secondary" className="gap-1">
+          <Loader2 className="h-3 w-3 animate-spin" /> Searching…
+        </Badge>
+      );
+    }
+    if (status === "focused_crawl_running") {
+      return <Badge variant="outline">Focused crawl running</Badge>;
+    }
+    if (status === "warming") {
+      return <Badge variant="destructive">Embedding warming</Badge>;
+    }
+    if (status === "error") {
+      return <Badge variant="destructive">Search error</Badge>;
+    }
+    if (llmUsed) {
+      return <Badge variant="outline">LLM rerank</Badge>;
+    }
+    return null;
+  }, [status, llmUsed]);
+
+  return (
+    <div className={cn("flex flex-col bg-background", className)}>
+      <div className="flex items-start justify-between gap-2 border-b px-3 py-2">
+        <div className="min-w-0 space-y-1">
+          <div className="flex items-center gap-2 text-xs uppercase text-muted-foreground">
+            <SearchIcon className="h-3.5 w-3.5" />
+            <span>Local search</span>
+            {lastFetchedAt ? (
+              <span className="lowercase">· Updated {new Date(lastFetchedAt).toLocaleTimeString()}</span>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="truncate text-sm font-semibold">
+              {hasQuery ? query : "Type a query to search the index"}
+            </h2>
+            {statusBadge}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {onRefresh ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={onRefresh}
+              disabled={!hasQuery || isLoading}
+              aria-label="Refresh search results"
+            >
+              {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
+            </Button>
+          ) : null}
+          {onAskAgent ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => onAskAgent(query)}
+              disabled={!hasQuery || isLoading}
+            >
+              Ask agent
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {normalizedConfidence !== null ? (
+        <div className="flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Confidence</span>
+          <Progress value={normalizedConfidence} className="h-1.5 flex-1" />
+          <span>{normalizedConfidence}%</span>
+        </div>
+      ) : null}
+
+      {status === "focused_crawl_running" ? (
+        <div className="space-y-1 border-b px-3 py-2 text-xs text-muted-foreground">
+          <p>
+            Focused crawl queued{jobId ? ` (job ${jobId})` : ""}
+            {triggerLabel ? ` after ${triggerLabel}` : ""}.
+          </p>
+          {typeof seedCount === "number" ? (
+            <p>{seedCount} frontier seeds dispatched for exploration.</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {status === "warming" ? (
+        <div className="space-y-2 border-b px-3 py-2 text-xs text-muted-foreground">
+          <p>{detail ?? "Embedding model is starting up."}</p>
+          {code ? (
+            <p className="font-mono text-[11px] text-foreground">{code}</p>
+          ) : null}
+          {actionLabel ? (
+            <p className="font-mono text-[11px] text-foreground">{actionLabel}</p>
+          ) : null}
+          {candidates && candidates.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {candidates.map((candidate, index) => {
+                const label = typeof candidate?.model === "string" ? candidate.model : `Option ${index + 1}`;
+                return (
+                  <Badge key={label} variant="secondary">
+                    {label}
+                  </Badge>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {error && status !== "warming" ? (
+        <div className="flex items-start gap-2 border-b px-3 py-2 text-sm text-destructive">
+          <AlertTriangle className="mt-0.5 h-4 w-4" />
+          <div className="space-y-1">
+            <p>{error}</p>
+            {detail ? <p className="text-xs text-muted-foreground">{detail}</p> : null}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex-1 overflow-hidden">
+        {isLoading ? (
+          <div className="space-y-3 p-3">
+            {LOADING_PLACEHOLDERS.map((placeholder) => (
+              <div key={placeholder} className="space-y-2 rounded border p-3">
+                <Skeleton className="h-4 w-1/2" />
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-5/6" />
+              </div>
+            ))}
+          </div>
+        ) : hits.length > 0 ? (
+          <ScrollArea className="h-full">
+            <div className="space-y-2 p-3">
+              {hits.map((hit) => {
+                const isActive = currentUrl && hit.url && currentUrl === hit.url;
+                return (
+                  <button
+                    key={hit.id}
+                    type="button"
+                    onClick={() => hit.url && onOpenHit(hit.url)}
+                    disabled={!hit.url}
+                    className={cn(
+                      "group w-full rounded-lg border bg-card px-3 py-2 text-left shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isActive
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-primary/50 hover:bg-muted/60",
+                      !hit.url && "cursor-not-allowed opacity-70"
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium text-foreground">{hit.title}</p>
+                        {hit.snippet ? (
+                          <p
+                            className="line-clamp-2 text-xs text-muted-foreground"
+                            dangerouslySetInnerHTML={{ __html: hit.snippet }}
+                          />
+                        ) : null}
+                      </div>
+                      {hit.url ? (
+                        <ArrowUpRight className="mt-0.5 h-4 w-4 text-muted-foreground transition group-hover:text-foreground" />
+                      ) : null}
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                      {hit.url ? <span className="truncate font-mono text-[11px]">{hit.url}</span> : null}
+                      {typeof hit.score === "number" ? (
+                        <span>Score {hit.score.toFixed(2)}</span>
+                      ) : null}
+                      {typeof hit.blendedScore === "number" ? (
+                        <span>Blend {hit.blendedScore.toFixed(2)}</span>
+                      ) : null}
+                      {hit.lang ? <span>Lang {hit.lang}</span> : null}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        ) : hasQuery ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+            <SearchIcon className="h-6 w-6" />
+            <p>No results yet. Try refining your query or queue a crawl.</p>
+          </div>
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+            <SearchIcon className="h-6 w-6" />
+            <p>Enter a keyword above to search your local index.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -108,6 +108,35 @@ export interface ChatStreamChunk {
   load_duration?: number;
 }
 
+export type SearchResponseStatus = "ok" | "focused_crawl_running" | "warming" | string;
+
+export interface SearchHit {
+  id: string;
+  title: string;
+  url: string;
+  snippet: string;
+  score?: number | null;
+  blendedScore?: number | null;
+  lang?: string | null;
+}
+
+export interface SearchIndexResponse {
+  status: SearchResponseStatus;
+  hits: SearchHit[];
+  llmUsed: boolean;
+  jobId?: string;
+  lastIndexTime?: number;
+  confidence?: number;
+  triggerReason?: string;
+  seedCount?: number;
+  detail?: string;
+  error?: string;
+  code?: string;
+  action?: string;
+  candidates?: Array<Record<string, unknown>>;
+  embedderStatus?: Record<string, unknown>;
+}
+
 export interface JobLogEvent {
   type: "log" | "status" | "error";
   message?: string;


### PR DESCRIPTION
## Summary
- add a `searchIndex` helper that normalizes `/api/search` responses for the UI
- render a search results panel next to the preview/chat panes and update the omnibox to trigger searches
- document the combined search/chat workflow and cover the new panel with a smoke test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6161f93bc8321a3d30158e2b8f775