### PR TITLE
Fix dev stack port defaults and cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Flask / UI
 FLASK_RUN_HOST=127.0.0.1
-FLASK_RUN_PORT=5000
+FLASK_RUN_PORT=5050
 
 # Ollama embedding + chat models
 OLLAMA_URL=http://127.0.0.1:11434

--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,17 @@ setup:
 
 dev:
 	@bash -c 'set -euo pipefail; \
-	  FRONTEND_DIR="$(REPO_ROOT)/frontend"; \
-	  FRONTEND_PORT="$${FRONTEND_PORT:-3100}"; \
-	  set -a; [ -f .env ] && source .env; set +a; \
-	  INDEX_DIR="${INDEX_DIR:-./data/whoosh}"; \
-	  CRAWL_STORE="${CRAWL_STORE:-./data/crawl}"; \
-	  NORMALIZED_PATH="${NORMALIZED_PATH:-./data/normalized/normalized.jsonl}"; \
-	  CHROMA_PERSIST_DIR="${CHROMA_PERSIST_DIR:-./data/chroma}"; \
-	  CHROMADB_DISABLE_TELEMETRY="${CHROMADB_DISABLE_TELEMETRY:-1}"; \
-	  FLASK_RUN_PORT="${UI_PORT:-${FLASK_RUN_PORT:-5000}}"; \
-	  FLASK_RUN_HOST="${FLASK_RUN_HOST:-127.0.0.1}"; \
+          FRONTEND_DIR="$(REPO_ROOT)/frontend"; \
+          set -a; [ -f .env ] && source .env; set +a; \
+          FRONTEND_HOST="$${FRONTEND_HOST:-0.0.0.0}"; \
+          FRONTEND_PORT="$${FRONTEND_PORT:-3100}"; \
+          INDEX_DIR="${INDEX_DIR:-./data/whoosh}"; \
+          CRAWL_STORE="${CRAWL_STORE:-./data/crawl}"; \
+          NORMALIZED_PATH="${NORMALIZED_PATH:-./data/normalized/normalized.jsonl}"; \
+          CHROMA_PERSIST_DIR="${CHROMA_PERSIST_DIR:-./data/chroma}"; \
+          CHROMADB_DISABLE_TELEMETRY="${CHROMADB_DISABLE_TELEMETRY:-1}"; \
+          FLASK_RUN_PORT="$${UI_PORT:-$${FLASK_RUN_PORT:-5050}}"; \
+          FLASK_RUN_HOST="$${FLASK_RUN_HOST:-127.0.0.1}"; \
 	  API_HOST="$$FLASK_RUN_HOST"; \
 	  if [ "$$API_HOST" = "0.0.0.0" ]; then API_HOST="127.0.0.1"; fi; \
 	  export INDEX_DIR CRAWL_STORE NORMALIZED_PATH CHROMA_PERSIST_DIR CHROMADB_DISABLE_TELEMETRY FLASK_RUN_PORT FLASK_RUN_HOST; \
@@ -54,7 +55,7 @@ dev:
 	  $(PY) bin/dev_check.py; \
 	  pushd "$$FRONTEND_DIR" >/dev/null; \
 	  npm install >/dev/null; \
-	  NEXT_PUBLIC_API_BASE_URL="$$NEXT_PUBLIC_API_BASE_URL" npm run dev -- --hostname 0.0.0.0 --port "$$FRONTEND_PORT" & \
+	  NEXT_PUBLIC_API_BASE_URL="$$NEXT_PUBLIC_API_BASE_URL" npm run dev -- --hostname "$$FRONTEND_HOST" --port "$$FRONTEND_PORT" & \
 	  FRONTEND_PID=$$!; \
 	  popd >/dev/null; \
 	  echo "Frontend running at http://127.0.0.1:$$FRONTEND_PORT"; \
@@ -64,21 +65,22 @@ dev:
 	    if [ -n "${BACKEND_PID:-}" ]; then kill "$$BACKEND_PID" 2>/dev/null || true; fi; \
 	  }; \
 	  trap cleanup EXIT INT TERM; \
-          wait_for_any() { \
-            while :; do \
-              for pid in "$$@"; do \
-                if ! kill -0 "$$pid" 2>/dev/null; then \
-                  wait "$$pid" 2>/dev/null; \
-                  return $$?; \
-                fi; \
-              done; \
-              sleep 0.2; \
-            done; \
-          }; \
-          $(PY) -m flask --app app --debug run & \
-          BACKEND_PID=$$!; \
-          wait_for_any $$FRONTEND_PID $$BACKEND_PID; \
+	  wait_for_any() { \
+	    while :; do \
+	      for pid in "$$@"; do \
+	        if ! kill -0 "$$pid" 2>/dev/null; then \
+	          wait "$$pid" 2>/dev/null; \
+	          return $$?; \
+	        fi; \
+	      done; \
+	      sleep 0.2; \
+	    done; \
+	  }; \
+	  $(PY) -m flask --app app --debug run & \
+	  BACKEND_PID=$$!; \
+	  wait_for_any $$FRONTEND_PID $$BACKEND_PID; \
 	  STATUS=$$?; \
+	  if [ "$$STATUS" -ne 0 ]; then cleanup; fi; \
 	  wait $$FRONTEND_PID $$BACKEND_PID 2>/dev/null || true; \
 	  exit $$STATUS'
 

--- a/README.md
+++ b/README.md
@@ -102,13 +102,18 @@ make dev
 `make dev` performs the following:
 
 - Loads `.env` (if present) to populate environment variables.
-- Starts the Flask server (default `http://127.0.0.1:5000`).
-- Boots the Next.js dev server (default `http://127.0.0.1:3100`).
+- Starts the Flask server (default `http://127.0.0.1:5050`; overrides via
+  `UI_PORT` or `FLASK_RUN_PORT`).
+- Boots the Next.js dev server (default `http://127.0.0.1:3100`; override with
+  `FRONTEND_PORT`).
 - Exposes the API base URL to the frontend via `NEXT_PUBLIC_API_BASE_URL`.
-- Shuts everything down gracefully when you hit <kbd>Ctrl</kbd> + <kbd>C</kbd>.
+- Shuts everything down gracefully when you hit <kbd>Ctrl</kbd> + <kbd>C</kbd>,
+  even when one process exits early.
 
-Open the browser at `http://127.0.0.1:3100` to use the UI. The Flask server also
-serves a minimal UI at its root when you prefer not to run the Next.js app.
+Open the browser at `http://127.0.0.1:3100` to use the UI. If `127.0.0.1:5050`
+is busy (macOS ships AirPlay on that port), set `UI_PORT=5051 make dev` instead.
+The Flask server also serves a minimal UI at its root when you prefer not to run
+the Next.js app.
 
 ### Backend or frontend individually
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --hostname 0.0.0.0 --port 3100",
+    "dev": "next dev",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary
- default the Flask dev server to port 5050 and honour FRONTEND_HOST/FRONTEND_PORT overrides when running `make dev`
- stop double-passing host/port to the Next.js script and ensure the dev target cleans up when either process exits
- document the new defaults and update the sample `.env`

## Testing
- FRONTEND_PORT=4300 UI_PORT=5052 make dev

------
https://chatgpt.com/codex/tasks/task_e_68d9f31814688321840ed84dc70102a7