### PR TITLE
Add Ollama model picker, fallback chat handling, and request tracing

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -7,7 +7,9 @@ import logging
 from typing import Iterable, Iterator, List
 
 import requests
-from flask import Blueprint, Response, current_app, request, stream_with_context
+from flask import Blueprint, Response, current_app, g, jsonify, request, stream_with_context
+
+from server.json_logger import log_event
 
 from ..config import AppConfig
 
@@ -67,53 +69,44 @@ def _sanitize_messages(messages: List[dict]) -> list[dict[str, object]]:
     return sanitized
 
 
-def _ollama_chat_stream(url: str, payload: dict) -> Iterable[str]:
+def _iter_chat_chunks(response: requests.Response, *, model: str | None) -> Iterable[str]:
     logger = _resolve_logger()
-    logger.info(
-        "forwarding chat request to ollama url=%s model=%s",
-        url,
-        payload.get("model") or "<default>",
-    )
     try:
-        response = requests.post(url, json=payload, stream=True, timeout=120)
-    except requests.RequestException as exc:
-        logger.exception("ollama chat request failed")
-        message = json.dumps({"type": "error", "content": str(exc)})
-        yield f"data: {message}\n\n"
-        return
+        for line in response.iter_lines():
+            if not line:
+                continue
+            try:
+                chunk = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                logger.debug("discarding non-json chunk from ollama: %s", line)
+                continue
+            message = chunk.get("message", {})
+            content = message.get("content")
+            if content:
+                yield f"data: {json.dumps({'type': 'token', 'content': content})}\n\n"
+            if chunk.get("done"):
+                final = {
+                    "type": "done",
+                    "total_duration": chunk.get("total_duration"),
+                    "load_duration": chunk.get("load_duration"),
+                    "model": model,
+                }
+                yield f"data: {json.dumps(final)}\n\n"
+                break
+    finally:
+        response.close()
 
-    if response.status_code >= 400:
-        content_raw = response.text.strip() or f"HTTP {response.status_code}"
-        content = _truncate(content_raw, _MAX_ERROR_PREVIEW)
-        logger.error(
-            "ollama chat responded with HTTP %s: %s",
-            response.status_code,
-            content,
-        )
-        message = json.dumps({"type": "error", "content": content})
-        yield f"data: {message}\n\n"
-        return
 
-    for line in response.iter_lines():
-        if not line:
-            continue
-        try:
-            chunk = json.loads(line.decode("utf-8"))
-        except json.JSONDecodeError:
-            logger.debug("discarding non-json chunk from ollama: %s", line)
-            continue
-        message = chunk.get("message", {})
-        content = message.get("content")
-        if content:
-            yield f"data: {json.dumps({'type': 'token', 'content': content})}\n\n"
-        if chunk.get("done"):
-            final = {
-                "type": "done",
-                "total_duration": chunk.get("total_duration"),
-                "load_duration": chunk.get("load_duration"),
-            }
-            yield f"data: {json.dumps(final)}\n\n"
-            break
+def _configured_models() -> tuple[str, str | None, str | None]:
+    engine_config = current_app.config.get("RAG_ENGINE_CONFIG")
+    primary = "gpt-oss"
+    fallback: str | None = "gemma3"
+    embed: str | None = "embeddinggemma"
+    if engine_config is not None:
+        primary = (engine_config.models.llm_primary or primary).strip() or primary
+        fallback = (engine_config.models.llm_fallback or "").strip() or None
+        embed = (engine_config.models.embed or embed).strip() or embed
+    return primary, fallback, embed
 
 
 @bp.post("/chat")
@@ -125,13 +118,12 @@ def chat_stream() -> Response:
             "chat request rejected due to invalid messages payload: %s",
             type(messages).__name__,
         )
-        return Response(
-            json.dumps({"error": "messages must be a list"}),
-            status=400,
-            mimetype="application/json",
-        )
+        g.chat_error_class = "ValidationError"
+        g.chat_error_message = "messages must be a list"
+        return jsonify({"error": "messages must be a list", "trace_id": getattr(g, "trace_id", None)}), 400
     model = (payload.get("model") or "").strip() or None
 
+    trace_id = getattr(g, "trace_id", None)
     logger = _resolve_logger()
     logger.info(
         "chat request received model=%s prompts=%s",
@@ -139,13 +131,161 @@ def chat_stream() -> Response:
         json.dumps(_sanitize_messages(messages), ensure_ascii=False),
     )
 
+    primary_model, fallback_model, _ = _configured_models()
     config: AppConfig = current_app.config["APP_CONFIG"]
     url = f"{config.ollama_url}/api/chat"
-    body = {"messages": messages, "stream": True}
+
+    attempted: list[str] = []
+    missing_errors: list[str] = []
+    candidates: list[str] = []
     if model:
-        body["model"] = model
+        candidates.append(model)
+    else:
+        candidates.append(primary_model)
+        if fallback_model and fallback_model != primary_model:
+            candidates.append(fallback_model)
+
+    body_base = {"messages": messages, "stream": True}
+    selected_model: str | None = None
+    fallback_used = False
+
+    response: requests.Response | None = None
+    for index, candidate in enumerate(candidates):
+        attempted.append(candidate)
+        attempt_body = dict(body_base)
+        attempt_body["model"] = candidate
+        log_event(
+            "INFO",
+            "chat.request",
+            trace=trace_id,
+            model=candidate,
+            attempt=index + 1,
+        )
+        try:
+            response = requests.post(url, json=attempt_body, stream=True, timeout=120)
+        except requests.RequestException as exc:
+            g.chat_error_class = exc.__class__.__name__
+            g.chat_error_message = str(exc)
+            logger.exception("ollama chat request failed")
+            log_event(
+                "ERROR",
+                "chat.error",
+                trace=trace_id,
+                model=candidate,
+                error=g.chat_error_class,
+                msg=_truncate(str(exc), _MAX_ERROR_PREVIEW),
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "upstream_unavailable",
+                        "message": str(exc),
+                        "trace_id": trace_id,
+                    }
+                ),
+                502,
+            )
+
+        if response.status_code == 404:
+            content_raw = response.text.strip() or "model not found"
+            reason = _truncate(content_raw, _MAX_ERROR_PREVIEW)
+            logger.error(
+                "ollama chat responded with HTTP 404 for model %s: %s",
+                candidate,
+                reason,
+            )
+            log_event(
+                "ERROR",
+                "chat.error",
+                trace=trace_id,
+                model=candidate,
+                code=404,
+                msg=reason,
+            )
+            missing_errors.append(reason)
+            response.close()
+            continue
+
+        if response.status_code >= 400:
+            content_raw = response.text.strip() or f"HTTP {response.status_code}"
+            g.chat_error_class = "HTTPError"
+            g.chat_error_message = _truncate(content_raw, _MAX_ERROR_PREVIEW)
+            logger.error(
+                "ollama chat responded with HTTP %s for model %s: %s",
+                response.status_code,
+                candidate,
+                g.chat_error_message,
+            )
+            log_event(
+                "ERROR",
+                "chat.error",
+                trace=trace_id,
+                model=candidate,
+                code=response.status_code,
+                msg=g.chat_error_message,
+            )
+            response.close()
+            return (
+                jsonify(
+                    {
+                        "error": "upstream_error",
+                        "status": response.status_code,
+                        "message": g.chat_error_message,
+                        "trace_id": trace_id,
+                    }
+                ),
+                response.status_code,
+            )
+
+        selected_model = candidate
+        fallback_used = index > 0
+        break
+
+    if selected_model is None:
+        tried = [name for name in attempted if name]
+        hint = "ollama pull " + " or ".join(tried or [primary_model])
+        g.chat_error_class = "ModelNotFound"
+        combined = missing_errors[0] if missing_errors else hint
+        g.chat_error_message = combined
+        log_event(
+            "ERROR",
+            "chat.error",
+            trace=trace_id,
+            model=primary_model,
+            code=404,
+            msg=combined,
+        )
+        return (
+            jsonify(
+                {
+                    "error": "model_not_found",
+                    "tried": tried,
+                    "hint": hint,
+                    "trace_id": trace_id,
+                }
+            ),
+            503,
+        )
+
+    g.chat_model = selected_model
+    g.chat_fallback_used = fallback_used
+    g.chat_error_class = None
+    g.chat_error_message = None
 
     def generate() -> Iterator[str]:
-        yield from _ollama_chat_stream(url, body)
+        yield from _iter_chat_chunks(response, model=selected_model)
 
-    return Response(stream_with_context(generate()), mimetype="text/event-stream")
+    log_event(
+        "INFO",
+        "chat.ready",
+        trace=trace_id,
+        model=selected_model,
+        fallback_used=fallback_used,
+    )
+
+    stream = Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+    )
+    stream.headers["X-LLM-Model"] = selected_model
+    return stream

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -23,6 +23,9 @@ const nextConfig = {
       },
     ];
   },
+  experimental: {
+    allowedDevOrigins: ["http://127.0.0.1:3100", "http://localhost:3100"],
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/components/__tests__/selection-actions.test.tsx
+++ b/frontend/src/components/__tests__/selection-actions.test.tsx
@@ -151,6 +151,10 @@ describe("selection action surfaces", () => {
         onApproveAction={() => undefined}
         onEditAction={() => undefined}
         onDismissAction={() => undefined}
+        modelOptions={["gpt-oss"]}
+        selectedModel="gpt-oss"
+        onModelChange={() => undefined}
+        noModelsWarning={null}
       />
     );
 

--- a/frontend/src/components/chat-panel.tsx
+++ b/frontend/src/components/chat-panel.tsx
@@ -9,6 +9,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type { ChatMessage, ProposedAction } from "@/lib/types";
 
@@ -23,6 +30,10 @@ interface ChatPanelProps {
   onEditAction: (action: ProposedAction) => void;
   onDismissAction: (action: ProposedAction) => void;
   onUploadFile?: () => void;
+  modelOptions: string[];
+  selectedModel: string | null;
+  onModelChange: (model: string) => void;
+  noModelsWarning?: string | null;
 }
 
 export function ChatPanel({
@@ -36,6 +47,10 @@ export function ChatPanel({
   onEditAction,
   onDismissAction,
   onUploadFile,
+  modelOptions,
+  selectedModel,
+  onModelChange,
+  noModelsWarning,
 }: ChatPanelProps) {
   const formRef = useRef<HTMLFormElement | null>(null);
   const endRef = useRef<HTMLDivElement | null>(null);
@@ -65,13 +80,39 @@ export function ChatPanel({
 
   return (
     <Card className="flex h-full flex-col">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm">Copilot chat</CardTitle>
-          <div className="flex gap-2 text-xs text-muted-foreground">
-            <span>Streaming {isStreaming ? "live" : "idle"}</span>
+      <CardHeader className="space-y-2 pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle className="text-sm">Copilot chat</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Streaming {isStreaming ? "live" : "idle"}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted-foreground">Model</span>
+            <Select
+              value={selectedModel ?? undefined}
+              onValueChange={onModelChange}
+              disabled={modelOptions.length === 0}
+            >
+              <SelectTrigger className="h-8 w-44">
+                <SelectValue placeholder="Select model" />
+              </SelectTrigger>
+              <SelectContent>
+                {modelOptions.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
+        {noModelsWarning ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {noModelsWarning}
+          </div>
+        ) : null}
       </CardHeader>
       <CardContent className="flex-1 overflow-hidden">
         <ScrollArea className="h-full pr-4">

--- a/frontend/src/components/toast-container.tsx
+++ b/frontend/src/components/toast-container.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+export interface ToastMessage {
+  id: string;
+  message: string;
+  variant?: "default" | "destructive";
+  traceId?: string | null;
+}
+
+interface ToastContainerProps {
+  toasts: ToastMessage[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastContainer({ toasts, onDismiss }: ToastContainerProps) {
+  useEffect(() => {
+    const timers = toasts.map((toast) =>
+      window.setTimeout(() => onDismiss(toast.id), 6000),
+    );
+    return () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [toasts, onDismiss]);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed right-4 top-4 z-50 flex w-80 max-w-full flex-col gap-3">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={cn(
+            "pointer-events-auto rounded-md border px-4 py-3 text-sm shadow-md",
+            toast.variant === "destructive"
+              ? "border-destructive/60 bg-destructive/10 text-destructive"
+              : "border-foreground/20 bg-background/95 text-foreground",
+          )}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <p className="font-medium leading-snug">{toast.message}</p>
+              {toast.traceId ? (
+                <p className="text-xs text-muted-foreground">trace: {toast.traceId}</p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="text-xs text-muted-foreground transition hover:text-foreground"
+              onClick={() => onDismiss(toast.id)}
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchModelInventory, streamChat, ChatRequestError } from "@/lib/api";
+import type { ChatMessage } from "@/lib/types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchModelInventory", () => {
+  it("parses available models and configuration", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (typeof input === "string" && input.includes("/api/llm/models")) {
+        return new Response(
+          JSON.stringify({
+            available: ["gpt-oss", "gemma3"],
+            configured: {
+              primary: "gpt-oss",
+              fallback: "gemma3",
+              embedder: "embeddinggemma",
+            },
+            ollama_host: "http://127.0.0.1:11434",
+          }),
+          { status: 200 },
+        );
+      }
+      if (typeof input === "string" && input.includes("/api/llm/health")) {
+        return new Response(
+          JSON.stringify({ reachable: true, model_count: 2, duration_ms: 5 }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`Unexpected fetch ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const inventory = await fetchModelInventory();
+    expect(inventory.available).toEqual(["gpt-oss", "gemma3"]);
+    expect(inventory.configured.primary).toBe("gpt-oss");
+    expect(inventory.status.running).toBe(true);
+    expect(inventory.models[0].model).toBe("gpt-oss");
+  });
+});
+
+describe("streamChat", () => {
+  it("sends the selected model and returns trace info", async () => {
+    const history: ChatMessage[] = [];
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"type":"done"}\n\n'));
+        controller.close();
+      },
+    });
+    const response = new Response(stream, {
+      status: 200,
+      headers: {
+        "X-Request-Id": "req_test",
+        "X-LLM-Model": "gemma3",
+      },
+    });
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = init?.body as string;
+      const payload = JSON.parse(body);
+      expect(payload.model).toBe("gpt-oss");
+      return response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events: string[] = [];
+    const result = await streamChat(history, "hi", {
+      model: "gpt-oss",
+      onEvent: (chunk) => {
+        if (chunk.type === "done") {
+          events.push("done");
+        }
+      },
+    });
+
+    expect(events).toContain("done");
+    expect(result.traceId).toBe("req_test");
+    expect(result.model).toBe("gemma3");
+  });
+
+  it("throws ChatRequestError with metadata when upstream fails", async () => {
+    const errorResponse = new Response(
+      JSON.stringify({ error: "model_not_found", hint: "ollama pull gpt-oss" }),
+      {
+        status: 503,
+        headers: { "X-Request-Id": "req_fail" },
+      },
+    );
+    const fetchMock = vi.fn(async () => errorResponse);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      streamChat([], "hi", { model: "gpt-oss", onEvent: () => {} }),
+    ).rejects.toMatchObject({
+      traceId: "req_fail",
+      hint: "ollama pull gpt-oss",
+      code: "model_not_found",
+    } satisfies Partial<ChatRequestError>);
+  });
+});

--- a/frontend/src/lib/__tests__/chat-model.test.ts
+++ b/frontend/src/lib/__tests__/chat-model.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveChatModelSelection } from "@/lib/chat-model";
+import type { ConfiguredModels } from "@/lib/types";
+
+describe("resolveChatModelSelection", () => {
+  const configured: ConfiguredModels = {
+    primary: "gpt-oss",
+    fallback: "gemma3",
+    embedder: "embeddinggemma",
+  };
+
+  it("prefers previous model when still available", () => {
+    const result = resolveChatModelSelection({
+      available: ["gpt-oss", "gemma3"],
+      configured,
+      stored: "gemma3",
+      previous: "gemma3",
+    });
+    expect(result).toBe("gemma3");
+  });
+
+  it("falls back to stored value when previous is unavailable", () => {
+    const result = resolveChatModelSelection({
+      available: ["gpt-oss", "gemma3"],
+      configured,
+      stored: "gemma3",
+      previous: "missing-model",
+    });
+    expect(result).toBe("gemma3");
+  });
+
+  it("returns configured primary when no stored value exists", () => {
+    const result = resolveChatModelSelection({
+      available: ["gpt-oss"],
+      configured,
+      stored: null,
+      previous: null,
+    });
+    expect(result).toBe("gpt-oss");
+  });
+
+  it("returns null when nothing is available", () => {
+    const result = resolveChatModelSelection({
+      available: [],
+      configured: { primary: null, fallback: null, embedder: null },
+      stored: null,
+      previous: null,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/lib/chat-model.ts
+++ b/frontend/src/lib/chat-model.ts
@@ -1,0 +1,39 @@
+import type { ConfiguredModels } from "@/lib/types";
+
+interface ResolveOptions {
+  available: string[];
+  configured: ConfiguredModels;
+  stored: string | null;
+  previous: string | null;
+}
+
+export function resolveChatModelSelection({
+  available,
+  configured,
+  stored,
+  previous,
+}: ResolveOptions): string | null {
+  const uniqueAvailable = Array.from(new Set(available.filter(Boolean)));
+
+  if (previous && uniqueAvailable.includes(previous)) {
+    return previous;
+  }
+
+  if (stored && uniqueAvailable.includes(stored)) {
+    return stored;
+  }
+
+  if (configured.primary && uniqueAvailable.includes(configured.primary)) {
+    return configured.primary;
+  }
+
+  if (uniqueAvailable.length > 0) {
+    return uniqueAvailable[0];
+  }
+
+  if (configured.primary) {
+    return configured.primary;
+  }
+
+  return null;
+}

--- a/frontend/src/lib/devlog.ts
+++ b/frontend/src/lib/devlog.ts
@@ -1,0 +1,12 @@
+const isDev = process.env.NODE_ENV === "development";
+
+type LogPayload = Record<string, unknown> | undefined;
+
+export function devlog(event: string, payload?: LogPayload) {
+  if (!isDev) return;
+  const parts: unknown[] = ["[UI]", event];
+  if (payload && Object.keys(payload).length > 0) {
+    parts.push(payload);
+  }
+  console.debug(...parts);
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -88,11 +88,30 @@ export interface SeedRegistryResponse {
 
 export interface ModelStatus {
   model: string;
-  installed: boolean;
-  available: boolean;
+  installed?: boolean;
+  available?: boolean;
   isPrimary?: boolean;
   kind: "chat" | "embedding";
   role?: "primary" | "fallback" | "embedding" | "extra";
+}
+
+export interface ConfiguredModels {
+  primary: string | null;
+  fallback: string | null;
+  embedder: string | null;
+}
+
+export interface LlmModelsResponse {
+  available: string[];
+  configured: ConfiguredModels;
+  ollama_host: string;
+}
+
+export interface LlmHealth {
+  reachable: boolean;
+  model_count: number;
+  duration_ms: number;
+  host?: string;
 }
 
 export interface OllamaStatus {

--- a/scripts/dev_verify.sh
+++ b/scripts/dev_verify.sh
@@ -15,12 +15,22 @@ printf '== Ollama tags ==\n'
 curl -s http://127.0.0.1:11434/api/tags | jq '.models[].name' | grep -E 'gpt-oss|gemma3|embeddinggemma'
 
 echo
-printf '== Backend model inventory ==\n'
+printf '== Backend LLM models ==\n'
 curl -sS http://127.0.0.1:5050/api/llm/models | jq .
 
 echo
-printf '== Backend LLM status ==\n'
+printf '== Backend LLM health ==\n'
+curl -sS http://127.0.0.1:5050/api/llm/health | jq .
+
+echo
+printf '== Backend LLM status (legacy) ==\n'
 curl -sS http://127.0.0.1:5050/api/llm/status | jq .
+
+echo
+printf '== Chat endpoint (fallback demo) ==\n'
+curl -sS -X POST http://127.0.0.1:5050/api/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-oss","messages":[{"role":"user","content":"say hi"}]}' | jq .
 
 echo
 printf '== Embedder status ==\n'

--- a/tests/unit/test_chat_endpoint.py
+++ b/tests/unit/test_chat_endpoint.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from backend.app import create_app
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        lines: List[Dict[str, Any]] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self._lines = lines or []
+        self._text = text
+        self.headers: Dict[str, str] = {}
+
+    def iter_lines(self):  # pragma: no cover - behaviour exercised in tests
+        for line in self._lines:
+            yield json.dumps(line).encode("utf-8")
+
+    def close(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    application = create_app()
+    return application
+
+
+def test_chat_retries_with_fallback(monkeypatch: pytest.MonkeyPatch, app) -> None:
+    attempts: List[Dict[str, Any]] = []
+
+    responses = [
+        _FakeResponse(status_code=404, text='{"error":"model not found"}'),
+        _FakeResponse(
+            status_code=200,
+            lines=[
+                {"message": {"content": "Hello"}},
+                {"done": True, "total_duration": 123, "load_duration": 45},
+            ],
+        ),
+    ]
+
+    def _fake_post(url: str, json: Dict[str, Any], stream: bool, timeout: int = 0):
+        attempts.append(json)
+        return responses[len(attempts) - 1]
+
+    monkeypatch.setattr("backend.app.api.chat.requests.post", _fake_post)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/chat",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    body = response.data.decode("utf-8")
+    assert response.status_code == 200
+    assert "Hello" in body
+    assert attempts[0]["model"] == "gpt-oss"
+    assert attempts[1]["model"] == "gemma3"
+    assert response.headers["X-LLM-Model"] == "gemma3"
+
+
+def test_chat_returns_model_not_found(monkeypatch: pytest.MonkeyPatch, app) -> None:
+    attempts: List[Dict[str, Any]] = []
+
+    def _fake_post(url: str, json: Dict[str, Any], stream: bool, timeout: int = 0):
+        attempts.append(json)
+        return _FakeResponse(status_code=404, text='{"error":"model not found"}')
+
+    monkeypatch.setattr("backend.app.api.chat.requests.post", _fake_post)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/chat",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    payload = response.get_json()
+    assert response.status_code == 503
+    assert payload["error"] == "model_not_found"
+    assert payload["tried"] == ["gpt-oss", "gemma3"]
+    assert "ollama pull" in payload["hint"]

--- a/tests/unit/test_request_trace.py
+++ b/tests/unit/test_request_trace.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import g, jsonify
+
+from backend.app import create_app
+
+
+def test_request_trace_header(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    app = create_app()
+
+    @app.get("/trace-check")
+    def trace_check():
+        return jsonify({"trace": getattr(g, "trace_id", None)})
+
+    client = app.test_client()
+    response = client.get("/trace-check")
+    payload = response.get_json()
+    trace = payload["trace"]
+
+    assert isinstance(trace, str)
+    assert trace.startswith("req_")
+    assert response.headers["X-Request-Id"] == trace


### PR DESCRIPTION
## Summary
- add JSON trace middleware and enrich chat handler with model retry plus new llm health/models endpoints
- expose Ollama model inventory in the UI with a persistent chat model selector, dev console logs, and failure toasts
- document new workflows and extend dev verification script with llm checks

## Testing
- pytest tests/unit
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68da0aeed0508321a17a5ebd943e9fe9