### PR TITLE
Fix dev server host bindings for remote access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ dev:
 	  echo "Starting API-only backend and Next.js UI..."; \
 	  set -a; [ -f .env ] && source .env; set +a; \
 	  FRONTEND_PORT="$${FRONTEND_PORT:-3100}"; \
-	  FRONTEND_HOST="$${FRONTEND_HOST:-127.0.0.1}"; \
-	  BACKEND_PORT="$${BACKEND_PORT:-5050}"; \
-	  BACKEND_HOST="$${BACKEND_HOST:-127.0.0.1}"; \
+          FRONTEND_HOST="$${FRONTEND_HOST:-0.0.0.0}"; \
+          BACKEND_PORT="$${BACKEND_PORT:-5050}"; \
+          BACKEND_HOST="$${BACKEND_HOST:-0.0.0.0}"; \
 	  BACKEND_RELOAD="$${BACKEND_RELOAD:-0}"; \
 	  FLASK_RELOAD_FLAG="--no-reload"; \
 	  if [ "$$BACKEND_RELOAD" = "1" ]; then FLASK_RELOAD_FLAG="--reload"; fi; \
@@ -53,12 +53,16 @@ dev:
 	  export INDEX_DIR CRAWL_STORE NORMALIZED_PATH CHROMA_PERSIST_DIR CHROMADB_DISABLE_TELEMETRY; \
 	  PYTHON_BIN="$(PY)"; \
 	  if [ ! -x "$$PYTHON_BIN" ]; then PYTHON_BIN="$(PYTHON)"; fi; \
-	  trap 'kill 0' EXIT INT TERM; \
+          trap "kill 0" EXIT INT TERM; \
 	  "$$PYTHON_BIN" -m flask --app app --debug run $$FLASK_RELOAD_FLAG --host "$$BACKEND_HOST" --port "$$BACKEND_PORT" & \
 	  BACK_PID=$$!; \
 	  (cd frontend && npm install >/dev/null && npm run dev -- --hostname "$$FRONTEND_HOST" --port "$$FRONTEND_PORT") & \
 	  FRONT_PID=$$!; \
-	  echo "UI: http://127.0.0.1:$$FRONTEND_PORT | API: http://127.0.0.1:$$BACKEND_PORT"; \
+          DISPLAY_FRONT_HOST="$$FRONTEND_HOST"; \
+          if [ "$$DISPLAY_FRONT_HOST" = "0.0.0.0" ]; then DISPLAY_FRONT_HOST="localhost"; fi; \
+          DISPLAY_BACK_HOST="$$BACKEND_HOST"; \
+          if [ "$$DISPLAY_BACK_HOST" = "0.0.0.0" ]; then DISPLAY_BACK_HOST="localhost"; fi; \
+          echo "UI: http://$$DISPLAY_FRONT_HOST:$$FRONTEND_PORT (bound to $$FRONTEND_HOST) | API: http://$$DISPLAY_BACK_HOST:$$BACKEND_PORT (bound to $$BACKEND_HOST)"; \
 	  wait $$BACK_PID $$FRONT_PID'
 
 stop:

--- a/README.md
+++ b/README.md
@@ -106,18 +106,19 @@ make dev
 
 - Loads `.env` (if present) to populate environment variables.
 - Exports crawl/index directories so both processes share the same data roots.
-- Starts the Flask API only (default `http://127.0.0.1:5050`; override with
+- Starts the Flask API only (binds to `0.0.0.0` and is reachable at
+  `http://localhost:5050` from the host; override with
   `BACKEND_PORT`). Auto-reload stays off so a `git pull` or file sync won't
   restart your dev server; opt back in with `BACKEND_RELOAD=1 make dev`.
-- Boots the Next.js dev server (default `http://127.0.0.1:3100`; override with
-  `FRONTEND_PORT`).
+- Boots the Next.js dev server (binds to `0.0.0.0` and is reachable at
+  `http://localhost:3100`; override with `FRONTEND_PORT`).
 - Tears both processes down when either exits or you press
   <kbd>Ctrl</kbd> + <kbd>C</kbd>.
 
 Run `make stop` to terminate lingering dev servers from another terminal
 without hunting for process IDs.
 
-Open the browser at `http://127.0.0.1:3100` to use the UI. If `127.0.0.1:5050`
+Open the browser at `http://localhost:3100` to use the UI. If `localhost:5050`
 is busy (macOS ships AirPlay on that port), run `BACKEND_PORT=5051 make dev`
 instead. The Flask API root now returns a JSON 404 to indicate that the UI lives
 entirely in Next.js.


### PR DESCRIPTION
## Summary
- bind both Flask and Next.js dev servers to 0.0.0.0 so the UI is reachable outside the container
- display the bound host in the dev helper message while keeping localhost-friendly URLs
- document the new defaults in the README

## Testing
- make dev

------
https://chatgpt.com/codex/tasks/task_e_68db5a3bfcbc8321b5185885f1138ffd