### PR TITLE
Improve dev startup and chat UX resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,30 @@ make dev
   `http://localhost:5050` from the host; override with
   `BACKEND_PORT`). Auto-reload stays off so a `git pull` or file sync won't
   restart your dev server; opt back in with `BACKEND_RELOAD=1 make dev`.
-- Boots the Next.js dev server (binds to `0.0.0.0` and is reachable at
-  `http://localhost:3100`; override with `FRONTEND_PORT`).
+- Waits for `/api/llm/health` to report ready before booting the frontend. The
+  command aborts if the API never becomes healthy, preventing the UI from
+  spamming `ECONNREFUSED` during startup.
+- Installs frontend dependencies on demand (skips work when `node_modules`
+  already exists) and starts the Next.js dev server (binds to `0.0.0.0` and is
+  reachable at `http://localhost:3100`; override with `FRONTEND_PORT`).
+- Streams frontend dev instrumentation (via `/api/dev/log`) into the backend
+  terminal so you can observe chat/search actions alongside Flask logs.
 - Tears both processes down when either exits or you press
   <kbd>Ctrl</kbd> + <kbd>C</kbd>.
+
+If Ollama is running but no chat-capable models are installed, the UI
+automatically calls `/api/llm/autopull` to download `gemma3` (falling back to
+`gpt-oss`). Expect the first run of `make dev` to spend a few minutes fetching
+model weights.
 
 Run `make stop` to terminate lingering dev servers from another terminal
 without hunting for process IDs.
 
-Open the browser at `http://localhost:3100` to use the UI. If `localhost:5050`
-is busy (macOS ships AirPlay on that port), run `BACKEND_PORT=5051 make dev`
-instead. The Flask API root now returns a JSON 404 to indicate that the UI lives
-entirely in Next.js.
+Open the browser at `http://localhost:3100` to use the UI. Make sure `ollama`
+is listening on `http://127.0.0.1:11434` (or adjust `OLLAMA_HOST`). If
+`localhost:5050` is busy (macOS ships AirPlay on that port), run
+`BACKEND_PORT=5051 make dev` instead. The Flask API root now returns a JSON 404
+to indicate that the UI lives entirely in Next.js.
 
 Verify the stack after startup with:
 

--- a/frontend/src/components/chat-panel.tsx
+++ b/frontend/src/components/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { ChevronDown, ChevronUp, Loader2, StopCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, type ReactNode } from "react";
+import { ChevronDown, Loader2, StopCircle } from "lucide-react";
 
 import { ActionCard } from "@/components/action-card";
 import { Button } from "@/components/ui/button";
@@ -49,8 +49,6 @@ export function ChatPanel({
 }: ChatPanelProps) {
   const formRef = useRef<HTMLFormElement | null>(null);
   const endRef = useRef<HTMLDivElement | null>(null);
-  const [expandedReasoning, setExpandedReasoning] = useState<Record<string, boolean>>({});
-
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages.length, isBusy]);
@@ -63,10 +61,6 @@ export function ChatPanel({
     },
     [input, onSend],
   );
-
-  const toggleReasoning = useCallback((id: string) => {
-    setExpandedReasoning((prev) => ({ ...prev, [id]: !prev[id] }));
-  }, []);
 
   return (
     <Card className="flex h-full flex-col">
@@ -92,10 +86,11 @@ export function ChatPanel({
             ) : null}
             {messages.map((message) => {
               const isAssistant = message.role === "assistant";
-              const reasoningId = `${message.id}:reasoning`;
-              const reasoningOpen = Boolean(expandedReasoning[reasoningId]);
               const reasoningText = (message.reasoning ?? "").trim();
-              const answerText = (message.answer ?? message.content ?? "").trim();
+              const answerText = (message.answer ?? "").trim();
+              const fallbackContent = (message.content ?? "").trim();
+              const displayAnswer = answerText || fallbackContent;
+              const hasReasoning = Boolean(reasoningText);
 
               return (
                 <div key={message.id} className="space-y-2">
@@ -113,28 +108,14 @@ export function ChatPanel({
                     <div className="space-y-3">
                       {isAssistant ? (
                         <div className="space-y-3">
-                          <div className="leading-relaxed whitespace-pre-wrap">{answerText || message.content}</div>
-                          {reasoningText ? (
-                            <div className="rounded-md border bg-muted/40 px-3 py-2 text-xs">
-                              <button
-                                type="button"
-                                className="flex w-full items-center justify-between text-left font-medium text-foreground"
-                                onClick={() => toggleReasoning(reasoningId)}
-                              >
-                                <span>Show reasoning (dev)</span>
-                                {reasoningOpen ? (
-                                  <ChevronUp className="h-3.5 w-3.5" />
-                                ) : (
-                                  <ChevronDown className="h-3.5 w-3.5" />
-                                )}
-                              </button>
-                              {reasoningOpen ? (
-                                <p className="mt-2 whitespace-pre-wrap text-foreground/90">
-                                  {reasoningText}
-                                </p>
-                              ) : null}
+                          <section className="space-y-2">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                              Answer
+                            </p>
+                            <div className="whitespace-pre-wrap leading-relaxed text-foreground">
+                              {displayAnswer}
                             </div>
-                          ) : null}
+                          </section>
                           {message.citations && message.citations.length > 0 ? (
                             <div className="space-y-1 text-xs text-muted-foreground">
                               <p className="font-medium text-foreground">Citations</p>
@@ -160,6 +141,17 @@ export function ChatPanel({
                                 })}
                               </ul>
                             </div>
+                          ) : null}
+                          {hasReasoning ? (
+                            <details className="group rounded-md border bg-muted/40 px-3 py-2 text-xs text-foreground/90">
+                              <summary className="flex cursor-pointer items-center justify-between font-medium text-foreground">
+                                <span>Show reasoning</span>
+                                <ChevronDown className="h-3.5 w-3.5 transition-transform group-open:rotate-180" />
+                              </summary>
+                              <div className="mt-2 whitespace-pre-wrap leading-relaxed text-foreground/90">
+                                {reasoningText}
+                              </div>
+                            </details>
                           ) : null}
                         </div>
                       ) : (

--- a/frontend/src/components/context-panel.tsx
+++ b/frontend/src/components/context-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import { Loader2, RefreshCw, Scissors, Trash2 } from "lucide-react";
 
@@ -21,6 +21,7 @@ interface ContextPanelProps {
   supportsVision: boolean;
   onManualSubmit: (text: string, title?: string) => void;
   onClear: () => void;
+  manualOpenTrigger?: number;
 }
 
 export function ContextPanel({
@@ -33,10 +34,17 @@ export function ContextPanel({
   supportsVision,
   onManualSubmit,
   onClear,
+  manualOpenTrigger = 0,
 }: ContextPanelProps) {
   const [manualOpen, setManualOpen] = useState(false);
   const [manualTitle, setManualTitle] = useState("");
   const [manualText, setManualText] = useState("");
+
+  useEffect(() => {
+    if (manualOpenTrigger > 0) {
+      setManualOpen(true);
+    }
+  }, [manualOpenTrigger]);
 
   const charCount = context?.text?.length ?? 0;
   const previewText = useMemo(() => {

--- a/frontend/src/lib/devlog.ts
+++ b/frontend/src/lib/devlog.ts
@@ -9,9 +9,34 @@ export function devlog(entry: Record<string, unknown>) {
     seq: ++seq,
     ...entry,
   };
+
+  let serialized: string | null = null;
   try {
-    console.debug(JSON.stringify(payload));
+    serialized = JSON.stringify(payload);
+    console.debug(serialized);
   } catch (error) {
     console.debug("{\"evt\":\"devlog.fallback\",\"error\":\"serialization_failed\"}");
+  }
+
+  if (typeof window === "undefined") return;
+
+  try {
+    const body =
+      serialized ??
+      JSON.stringify(payload, (_key, value) => {
+        if (value instanceof Error) {
+          return { name: value.name, message: value.message };
+        }
+        return value;
+      });
+    void fetch("/api/dev/log", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+      keepalive: true,
+      credentials: "same-origin",
+    }).catch(() => undefined);
+  } catch (error) {
+    console.debug("{\"evt\":\"devlog.fallback\",\"error\":\"forward_failed\"}");
   }
 }


### PR DESCRIPTION
## Summary
- ensure `make dev` waits for the Flask API health check before starting Next.js and only installs dependencies when needed
- add a `/api/dev/log` endpoint and forward frontend dev instrumentation so both stacks log to the same terminal during development
- auto-install a fallback chat model, fix chat abort handling, separate answer/reasoning rendering, and provide a manual context fallback when selection access is blocked

## Testing
- npm run test -- src/components/__tests__/selection-actions.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68db63ec91088321bbcf3889d8b11578