### PR TITLE
Handle stdbuf availability in dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,11 @@ dev:
   PYTHON_BIN="$(PY)"; \
   if [ ! -x "$$PYTHON_BIN" ]; then PYTHON_BIN="$(PYTHON)"; fi; \
   trap "kill 0" EXIT INT TERM; \
-  stdbuf -oL -eL "$$PYTHON_BIN" -m flask --app app --debug run $$FLASK_RELOAD_FLAG --host "$$BACKEND_HOST" --port "$$BACKEND_PORT" & \
+  if command -v stdbuf >/dev/null 2>&1; then \
+    stdbuf -oL -eL "$$PYTHON_BIN" -m flask --app app --debug run $$FLASK_RELOAD_FLAG --host "$$BACKEND_HOST" --port "$$BACKEND_PORT"; \
+  else \
+    PYTHONUNBUFFERED=1 "$$PYTHON_BIN" -m flask --app app --debug run $$FLASK_RELOAD_FLAG --host "$$BACKEND_HOST" --port "$$BACKEND_PORT"; \
+  fi & \
   BACK_PID=$$!; \
   HEALTH_URL="http://127.0.0.1:$$BACKEND_PORT/api/llm/health"; \
   echo "Waiting for backend at $$HEALTH_URL..."; \


### PR DESCRIPTION
## Summary
- detect stdbuf before wrapping the Flask dev server command and fall back to unbuffered Python when missing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc87c9dd748321b6aae0c461c8b688