### PR TITLE
Improve chat streaming resilience and diagnostics template

### DIFF
--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Iterable, Mapping
 from typing import Any, TYPE_CHECKING
 
-import requests
+from .. import requests as shared_requests
 from flask import Blueprint, current_app, g, jsonify, request
 
 from .. import EMBEDDING_MODEL_PATTERNS
@@ -80,13 +80,13 @@ def _probe_ollama(base_url: str, manager: "EmbeddingManager | None") -> dict[str
     error: str | None = None
     http_models: list[str] = []
     try:
-        response = requests.get(f"{base_url}/api/tags", timeout=3)
+        response = shared_requests.get(f"{base_url}/api/tags", timeout=3)
         response.raise_for_status()
         data = response.json()
         if isinstance(data, Mapping):
             http_models = _extract_models(data)
         reachable = True
-    except requests.RequestException as exc:
+    except shared_requests.RequestException as exc:
         error = str(exc)
     except ValueError:
         error = "invalid_json"

--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Self-Hosted Search Engine</title>
+  </head>
+  <body>
+    <main>
+      <h1>Self-Hosted Search Engine</h1>
+      <section id="diagnostics-panel">
+        <p>Diagnostics utilities</p>
+        <button id="diagnostics-run" type="button">Run diagnostics</button>
+        <button id="diagnostics-download" type="button">Download results</button>
+        <button id="diagnostics-log-download" type="button">Download logs</button>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- make the chat API stream responses safely, log user prompts, and tolerate unstructured content
- ensure the LLM API reuses the shared requests module so health checks can be mocked in tests
- add a minimal diagnostics index template and fall back to the legacy search service when RAG components are missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc8991e9148321b50d1025ac37c308