### PR TITLE
Remove unused selection error reset in web preview

### DIFF
--- a/frontend/src/components/web-preview.tsx
+++ b/frontend/src/components/web-preview.tsx
@@ -189,7 +189,8 @@ export function WebPreview({
           className="w-full h-full border-0"
           sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
           onLoad={() => {
-            setSelectionError(null);
+            // Previously attempted to clear a selection error state here, but no state setter exists.
+            // Keeping the handler in case future logic needs to respond to iframe load events.
           }}
         />
         {isLoading && (


### PR DESCRIPTION
## Summary
- remove the undefined `setSelectionError` call from the iframe load handler in the web preview component
- leave the load handler in place with a clarifying comment for future logic

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dc920c42588321a992d797bf3a5371