### PR TITLE
Fix make dev backend startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _MAIN_0.toc
 !backend/app/middleware/__init__.py
 !backend/app/services/ollama_client.py
 !backend/app/services/__init__.py
+!backend/app/__main__.py

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 FRONTEND_PORT ?= 3100
 BACKEND_PORT  ?= 5050
 API_URL := http://127.0.0.1:$(BACKEND_PORT)/api/llm/health
-VENV_PY := .venv/bin/python
+VENV_PY := $(CURDIR)/.venv/bin/python
 
 bootstrap:
 	@bash scripts/bootstrap.sh
@@ -11,7 +11,7 @@ bootstrap:
 dev:
 	@echo "▶ Starting API (Flask)…"
 	@if ! lsof -iTCP:$(BACKEND_PORT) -sTCP:LISTEN >/dev/null 2>&1; then \
-	  (cd backend && BACKEND_PORT=$(BACKEND_PORT) ../../$(VENV_PY) -m app &) ; \
+          (BACKEND_PORT=$(BACKEND_PORT) $(VENV_PY) -m backend.app &) ; \
 	fi
 	@echo "⏳ Waiting for API…"
 	@bash -c 'for i in $$(seq 1 60); do curl -fsS "$(API_URL)" >/dev/null && exit 0; sleep 0.5; done; echo "API not ready" >&2; exit 1'

--- a/backend/app/__main__.py
+++ b/backend/app/__main__.py
@@ -1,0 +1,40 @@
+"""Command line entry-point for running the Flask API."""
+from __future__ import annotations
+
+import logging
+import os
+
+from dotenv import load_dotenv
+
+from . import create_app
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> None:
+    """Create and run the Flask development server."""
+    load_dotenv()
+
+    app = create_app()
+
+    host = os.getenv("BACKEND_HOST", "0.0.0.0")
+    port = int(os.getenv("BACKEND_PORT", "5050"))
+    reload_enabled = _env_flag("BACKEND_RELOAD")
+
+    if reload_enabled:
+        LOGGER.info("Starting Flask dev server with auto reload enabled")
+    else:
+        LOGGER.info("Starting Flask dev server (no auto reload)")
+
+    app.run(host=host, port=port, debug=reload_enabled, use_reloader=reload_enabled)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- resolve the virtualenv invocation in `make dev` by using an absolute interpreter path
- launch the backend with `python -m backend.app` so imports resolve without editing PYTHONPATH
- add a module entry point for `backend.app` and whitelist it in `.gitignore`

## Testing
- make dev BACKEND_PORT=5055 FRONTEND_PORT=3100


------
https://chatgpt.com/codex/tasks/task_e_68dca8fc54bc8321be72ee242c6e1c9c