### PR TITLE
feat: expose embedding vector index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,11 @@ _MAIN_0.toc
 !server/json_logger.py
 !backend/app/api/llm.py
 !backend/app/api/extract.py
+!backend/app/api/index.py
 !backend/app/middleware/request_id.py
 !backend/app/middleware/__init__.py
 !backend/app/services/ollama_client.py
+!backend/app/services/vector_index.py
 !backend/app/services/__init__.py
 !backend/app/__main__.py
+!tests/api/test_index_api.py

--- a/backend/app/api/index.py
+++ b/backend/app/api/index.py
@@ -1,0 +1,95 @@
+"""Vector index management API."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from flask import Blueprint, current_app, jsonify, request
+
+from backend.app.services.vector_index import (
+    EmbedderUnavailableError,
+    VectorIndexService,
+)
+
+
+bp = Blueprint("index_api", __name__, url_prefix="/api/index")
+
+
+def _service() -> VectorIndexService:
+    service = current_app.config.get("VECTOR_INDEX_SERVICE")
+    if service is None:  # pragma: no cover - configured in app factory
+        raise RuntimeError("VECTOR_INDEX_SERVICE not configured")
+    return service
+
+
+def _coerce_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    return None
+
+
+def _coerce_metadata(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    return {str(key): item for key, item in value.items()}
+
+
+@bp.post("/upsert")
+def upsert_document() -> tuple[Any, int]:
+    payload = request.get_json(silent=True) or {}
+    text_raw = payload.get("text")
+    text_value = str(text_raw) if isinstance(text_raw, str) else None
+    if not text_value or not text_value.strip():
+        return jsonify({"error": "text is required"}), 400
+    url_value = _coerce_str(payload.get("url"))
+    title_value = _coerce_str(payload.get("title"))
+    metadata = _coerce_metadata(payload.get("meta"))
+    try:
+        result = _service().upsert_document(
+            text=text_value,
+            url=url_value,
+            title=title_value,
+            metadata=metadata,
+        )
+    except EmbedderUnavailableError as exc:
+        response = {
+            "error": "embedding_unavailable",
+            "detail": exc.detail,
+            "model": exc.model,
+        }
+        if exc.autopull_started:
+            response["autopull_started"] = True
+        return jsonify(response), 503
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(result.to_dict()), 200
+
+
+@bp.post("/search")
+def search_index() -> tuple[Any, int]:
+    payload = request.get_json(silent=True) or {}
+    query = _coerce_str(payload.get("query"))
+    if not query:
+        return jsonify({"error": "query is required"}), 400
+    k_value = payload.get("k", 5)
+    try:
+        k = max(1, int(k_value))
+    except (TypeError, ValueError):
+        return jsonify({"error": "k must be an integer"}), 400
+    filters = payload.get("filters") if isinstance(payload.get("filters"), Mapping) else None
+    try:
+        results = _service().search(query, k=k, filters=filters)
+    except EmbedderUnavailableError as exc:
+        response = {
+            "error": "embedding_unavailable",
+            "detail": exc.detail,
+            "model": exc.model,
+        }
+        if exc.autopull_started:
+            response["autopull_started"] = True
+        return jsonify(response), 503
+    return jsonify({"results": results}), 200
+
+
+__all__ = ["bp"]

--- a/backend/app/services/vector_index.py
+++ b/backend/app/services/vector_index.py
@@ -1,0 +1,320 @@
+"""Vector index orchestration backed by Chroma and Ollama embeddings."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from engine.config import EngineConfig
+from engine.data.store import VectorStore
+from engine.indexing.chunk import TokenChunker
+from engine.indexing.embed import EmbeddingError, OllamaEmbedder
+from engine.llm.ollama_client import OllamaClient, OllamaClientError
+
+from backend.app.config import AppConfig
+from backend.app.indexer.dedupe import SimHashIndex, simhash64
+from backend.app.search.embedding import embed_query as _fallback_embed
+from backend.app.services import ollama_client as ollama_services
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class IndexResult:
+    doc_id: str
+    chunks: int
+    dims: int
+    duplicate_of: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "doc_id": self.doc_id,
+            "chunks": self.chunks,
+            "dims": self.dims,
+        }
+        if self.duplicate_of:
+            payload["duplicate_of"] = self.duplicate_of
+        payload["skipped"] = self.chunks == 0
+        return payload
+
+
+@dataclass(slots=True)
+class SearchHit:
+    url: str | None
+    title: str | None
+    chunk: str
+    score: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "url": self.url,
+            "title": self.title,
+            "chunk": self.chunk,
+            "score": self.score,
+        }
+
+
+class EmbedderUnavailableError(RuntimeError):
+    """Raised when the configured embedding model is not available."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        detail: str | None = None,
+        autopull_started: bool = False,
+    ) -> None:
+        message = detail or f"Embedding model '{model}' is unavailable"
+        super().__init__(message)
+        self.model = model
+        self.detail = message
+        self.autopull_started = autopull_started
+
+
+class VectorIndexService:
+    """High level façade that coordinates embedding + Chroma persistence."""
+
+    _TEST_EMBED_DIMS = 128
+
+    def __init__(
+        self,
+        *,
+        engine_config: EngineConfig,
+        app_config: AppConfig,
+    ) -> None:
+        self._engine_config = engine_config
+        self._app_config = app_config
+        self._vector_store = VectorStore(
+            engine_config.index.persist_dir, engine_config.index.db_path
+        )
+        self._chunker = TokenChunker()
+        self._client = OllamaClient(engine_config.ollama.base_url)
+        self._embed_model = (engine_config.models.embed or "embeddinggemma").strip()
+        self._similarity_threshold = float(engine_config.retrieval.similarity_threshold)
+        self._dev_allow_autopull = bool(app_config.dev_allow_autopull)
+        self._autopull_started = False
+        self._lock = threading.RLock()
+        self._dedupe_path = app_config.agent_data_dir / "vector_simhash.json"
+        self._dedupe_path.parent.mkdir(parents=True, exist_ok=True)
+        self._simhash_index = SimHashIndex.load(self._dedupe_path)
+        self._last_dims = 0
+        self._test_mode = os.getenv("EMBED_TEST_MODE", "0").lower() in {
+            "1",
+            "true",
+            "on",
+        }
+        self._embedder: OllamaEmbedder | None = None
+        if not self._test_mode:
+            self._embedder = OllamaEmbedder(self._client, self._embed_model)
+        LOGGER.debug(
+            "vector index initialised (test_mode=%s, model=%s)",
+            self._test_mode,
+            self._embed_model,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def upsert_document(
+        self,
+        *,
+        text: str,
+        url: str | None = None,
+        title: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> IndexResult:
+        cleaned = (text or "").strip()
+        if not cleaned:
+            raise ValueError("text is required")
+        key = (url or "").strip()
+        doc_hash = hashlib.sha256(cleaned.encode("utf-8"), usedforsecurity=False).hexdigest()
+        storage_key = key or f"doc:{doc_hash}"
+        resolved_title = (title or key or "Untitled").strip() or storage_key
+        sim_signature = simhash64(cleaned)
+
+        with self._lock:
+            duplicate_key = self._simhash_index.nearest(sim_signature)
+            if duplicate_key and duplicate_key != storage_key:
+                LOGGER.debug(
+                    "dedupe skip for %s (duplicate of %s)", storage_key, duplicate_key
+                )
+                return IndexResult(
+                    doc_id=storage_key,
+                    chunks=0,
+                    dims=self._last_dims,
+                    duplicate_of=duplicate_key,
+                )
+            needs_update = self._vector_store.needs_update(
+                storage_key, None, doc_hash
+            )
+            if not needs_update:
+                self._simhash_index.update(storage_key, sim_signature)
+                self._persist_dedupe()
+                return IndexResult(doc_id=storage_key, chunks=0, dims=self._last_dims)
+
+        chunks = self._chunker.chunk_text(cleaned)
+        if not chunks:
+            with self._lock:
+                self._simhash_index.update(storage_key, sim_signature)
+                self._persist_dedupe()
+            return IndexResult(doc_id=storage_key, chunks=0, dims=self._last_dims)
+
+        vectors = self._embed_documents([chunk.text for chunk in chunks])
+        if len(vectors) != len(chunks):
+            raise EmbedderUnavailableError(
+                self._embed_model,
+                detail="embedding count mismatch",
+            )
+        dims = len(vectors[0]) if vectors else 0
+
+        with self._lock:
+            self._vector_store.upsert(
+                storage_key,
+                resolved_title,
+                None,
+                doc_hash,
+                chunks,
+                vectors,
+                metadata=metadata,
+                doc_id=storage_key,
+            )
+            self._simhash_index.update(storage_key, sim_signature)
+            self._persist_dedupe()
+            if dims:
+                self._last_dims = dims
+        LOGGER.info(
+            "indexed document %s (title=%s, chunks=%s, dims=%s)",
+            storage_key,
+            resolved_title,
+            len(chunks),
+            dims,
+        )
+        return IndexResult(doc_id=storage_key, chunks=len(chunks), dims=dims)
+
+    def search(
+        self,
+        query: str,
+        *,
+        k: int = 5,
+        filters: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        del filters  # currently unused but reserved for future metadata filters
+        cleaned = (query or "").strip()
+        if not cleaned:
+            return []
+        vector = self._embed_query(cleaned)
+        if not vector:
+            return []
+        retrieved = self._vector_store.query(vector, max(1, int(k)), self._similarity_threshold)
+        hits: list[SearchHit] = []
+        for item in retrieved:
+            hits.append(
+                SearchHit(
+                    url=item.url,
+                    title=item.title,
+                    chunk=item.text,
+                    score=float(item.similarity),
+                )
+            )
+        return [hit.to_dict() for hit in hits]
+
+    def metadata(self) -> dict[str, Any]:
+        dims = self._last_dims
+        if dims == 0:
+            dims = self._vector_store.embedding_dimensions()
+            if dims:
+                self._last_dims = dims
+        return {
+            "documents": self._vector_store.document_count(),
+            "dimensions": dims,
+            "model": self._embed_model,
+            "test_mode": self._test_mode,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _persist_dedupe(self) -> None:
+        try:
+            self._simhash_index.save(self._dedupe_path)
+        except Exception:  # pragma: no cover - persistence best effort
+            LOGGER.debug("failed to persist vector simhash index", exc_info=True)
+
+    def _ensure_embedder_ready(self) -> None:
+        if self._test_mode:
+            return
+        assert self._embedder is not None  # noqa: S101 - programming error guard
+        try:
+            available = self._client.has_model(self._embed_model)
+        except OllamaClientError as exc:
+            raise EmbedderUnavailableError(self._embed_model, detail=str(exc)) from exc
+        if available:
+            return
+        autopull_started = False
+        if self._dev_allow_autopull and not self._autopull_started:
+            try:
+                ollama_services.pull_model(self._embed_model, base_url=self._client.base_url)
+            except FileNotFoundError as exc:
+                LOGGER.warning("ollama CLI missing for autopull: %s", exc)
+            except Exception as exc:  # pragma: no cover - subprocess edge cases
+                LOGGER.warning("failed to start autopull for %s: %s", self._embed_model, exc)
+            else:
+                self._autopull_started = True
+                autopull_started = True
+                LOGGER.info(
+                    "auto-pulling embedding model %s from %s",
+                    self._embed_model,
+                    self._client.base_url,
+                )
+        detail = (
+            "embedding model is not available locally"
+            if not self._dev_allow_autopull
+            else "embedding model is warming up"
+        )
+        raise EmbedderUnavailableError(
+            self._embed_model,
+            detail=detail,
+            autopull_started=autopull_started,
+        )
+
+    def _embed_documents(self, texts: Sequence[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        if self._test_mode:
+            return [_fallback_embed(text, dimensions=self._TEST_EMBED_DIMS) for text in texts]
+        self._ensure_embedder_ready()
+        assert self._embedder is not None  # noqa: S101
+        try:
+            vectors = self._embedder.embed_documents(texts)
+        except EmbeddingError as exc:
+            raise EmbedderUnavailableError(self._embed_model, detail=str(exc)) from exc
+        if not vectors:
+            raise EmbedderUnavailableError(
+                self._embed_model,
+                detail="embedding response was empty",
+            )
+        LOGGER.debug(
+            "embedded %s chunks with %s",
+            len(vectors),
+            self._embed_model,
+        )
+        return vectors
+
+    def _embed_query(self, query: str) -> list[float]:
+        if self._test_mode:
+            return _fallback_embed(query, dimensions=self._TEST_EMBED_DIMS)
+        vectors = self._embed_documents([query])
+        return vectors[0] if vectors else []
+
+
+__all__ = [
+    "VectorIndexService",
+    "EmbedderUnavailableError",
+    "IndexResult",
+    "SearchHit",
+]

--- a/engine/config.py
+++ b/engine/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+
 import yaml
 
 
@@ -81,7 +82,10 @@ class EngineConfig:
 
         primary_value = models.get("llm_primary", "gpt-oss")
         fallback_value = models.get("llm_fallback", "gemma3")
-        embed_value = models.get("embed", "embeddinggemma")
+        embed_override = os.getenv("LLM_EMBEDDER") or os.getenv("EMBED_MODEL")
+        if embed_override is not None and not str(embed_override).strip():
+            embed_override = None
+        embed_value = embed_override or models.get("embed", "embeddinggemma")
         primary_text = str(primary_value).strip() if primary_value else ""
         fallback_text = str(fallback_value).strip() if fallback_value else ""
         embed_text = str(embed_value).strip() if embed_value else ""

--- a/tests/api/test_index_api.py
+++ b/tests/api/test_index_api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+
+from backend.app import create_app
+
+
+def test_index_upsert_and_search(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    chroma_dir = tmp_path / "chroma"
+    chroma_db = tmp_path / "index.duckdb"
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("CHROMA_PERSIST_DIR", str(chroma_dir))
+    monkeypatch.setenv("CHROMA_DB_PATH", str(chroma_db))
+    monkeypatch.setenv("EMBED_TEST_MODE", "1")
+    monkeypatch.setenv("FOCUSED_CRAWL_ENABLED", "0")
+    monkeypatch.setenv("LLM_EMBEDDER", "embeddinggemma")
+
+    app = create_app()
+    app.testing = True
+    client = app.test_client()
+
+    doc_id = uuid.uuid4().hex
+    upsert_payload = {
+        "url": f"https://example.com/{doc_id}",
+        "title": "Example Document",
+        "text": "Self-hosted search indexing relies on embeddinggemma vectors.",
+    }
+
+    upsert_response = client.post("/api/index/upsert", json=upsert_payload)
+    assert upsert_response.status_code == 200
+    upsert_data = upsert_response.get_json()
+    assert upsert_data["chunks"] > 0
+    assert upsert_data["dims"] == 128
+
+    search_response = client.post(
+        "/api/index/search",
+        json={"query": "embeddinggemma vectors", "k": 3},
+    )
+    assert search_response.status_code == 200
+    results = search_response.get_json().get("results")
+    assert results, "expected at least one vector search result"
+    assert any("embeddinggemma" in hit.get("chunk", "") for hit in results)


### PR DESCRIPTION
## Summary
- add a shared VectorIndexService backed by Chroma/Ollama with autopull-aware embedder checks and metadata support
- expose /api/index/upsert and /api/index/search endpoints and wire the agent runtime to consume the shared service
- extend the vector store utilities and engine config overrides to support embedding metadata and add a smoke test for the new API

## Testing
- pytest tests/api/test_index_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dcae2040fc832183a67ae244afc722