### PR TITLE
feat: add local discovery pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,11 +26,13 @@ _MAIN_0.toc
 !backend/app/api/agent_browser.py
 !backend/app/api/index.py
 !backend/app/api/shadow.py
+!backend/app/api/discovery.py
 !backend/app/middleware/request_id.py
 !backend/app/middleware/__init__.py
 !backend/app/services/ollama_client.py
 !backend/app/services/vector_index.py
 !backend/app/services/agent_browser.py
+!backend/app/services/local_discovery.py
 !backend/app/services/__init__.py
 !backend/app/__main__.py
 !backend/app/shadow/__init__.py
@@ -38,3 +40,4 @@ _MAIN_0.toc
 !tests/api/test_index_api.py
 !tests/api/test_shadow_api.py
 !tests/e2e/test_agent_browser.py
+!tests/backend/test_local_discovery.py

--- a/README.md
+++ b/README.md
@@ -380,6 +380,29 @@ triggers the flow the engine:
 - Persists the discovery metadata (query, URL, source, score) so subsequent
   searches can reuse the same domains without a fresh crawl.
 
+### Local file discovery
+
+Enable the local discovery watcher by setting `FEATURE_LOCAL_DISCOVERY=1` for
+the Flask API and `NEXT_PUBLIC_FEATURE_LOCAL_DISCOVERY=1` for the Next.js app
+(both defaults ship in the `.env.example` files). When active the backend starts
+a `watchdog` observer for two directories:
+
+- `~/Downloads` (if it exists)
+- `data/downloads` (always created so you can drop files from a headless
+  environment)
+
+New `.pdf`, `.html`, `.txt`, or `.md` files are parsed server-side (PDFs via
+`pdfminer`, HTML via BeautifulSoup) and broadcast to the UI using SSE. The UI
+shows a floating banner—"Found file: …"—with **Include** and **Dismiss**
+actions. Choosing **Include** calls `/api/index/upsert` with the extracted text
+and stores a confirmation so the same file will not be re-suggested after a
+restart. Dismissing records the file path and modification time in
+`data/agent/local_discovery_confirmations.json` so subsequent downloads with the
+same timestamp are ignored.
+
+Drop a PDF into either watch directory while the stack is running to see the
+notification and index the document on demand.
+
 ### Manual refresh controls
 
 Trigger a focused crawl on demand by clicking **Refresh now** in the web UI. The

--- a/backend/app/api/discovery.py
+++ b/backend/app/api/discovery.py
@@ -1,0 +1,107 @@
+"""Local discovery API surface."""
+
+from __future__ import annotations
+
+import json
+import queue
+from typing import Any
+
+from flask import Blueprint, Response, current_app, jsonify, request
+
+from backend.app.services.local_discovery import DiscoveryRecord, LocalDiscoveryService
+
+
+bp = Blueprint("discovery_api", __name__, url_prefix="/api/discovery")
+
+
+def _service() -> LocalDiscoveryService | None:
+    service = current_app.config.get("LOCAL_DISCOVERY_SERVICE")
+    if isinstance(service, LocalDiscoveryService):
+        return service
+    return None
+
+
+def _enabled() -> bool:
+    return bool(current_app.config.get("FEATURE_LOCAL_DISCOVERY"))
+
+
+def _serialize(record: DiscoveryRecord, *, include_text: bool) -> dict[str, Any]:
+    service = _service()
+    if service is None:  # pragma: no cover - guarded by caller
+        raise RuntimeError("Local discovery unavailable")
+    return service.to_dict(record, include_text=include_text)
+
+
+@bp.get("/events")
+def stream_events() -> Response:
+    if not _enabled():
+        return Response(status=404)
+
+    service = _service()
+    if service is None:
+        return jsonify({"error": "local_discovery_unavailable"}), 503
+
+    def generate() -> Any:
+        token, stream = service.subscribe()
+        try:
+            while True:
+                try:
+                    record = stream.get(timeout=15)
+                except queue.Empty:
+                    yield ": keep-alive\n\n"
+                    continue
+                if record is None:
+                    break
+                payload = json.dumps(_serialize(record, include_text=False))
+                yield f"data: {payload}\n\n"
+        finally:
+            service.unsubscribe(token)
+
+    response = Response(generate(), mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
+
+
+@bp.get("/item/<string:record_id>")
+def get_item(record_id: str):
+    if not _enabled():
+        return jsonify({"error": "local_discovery_disabled"}), 404
+
+    service = _service()
+    if service is None:
+        return jsonify({"error": "local_discovery_unavailable"}), 503
+
+    record = service.get(record_id)
+    if record is None:
+        return jsonify({"error": "not_found"}), 404
+
+    return jsonify(_serialize(record, include_text=True)), 200
+
+
+@bp.post("/confirm")
+def confirm_item():
+    if not _enabled():
+        return jsonify({"error": "local_discovery_disabled"}), 404
+
+    service = _service()
+    if service is None:
+        return jsonify({"error": "local_discovery_unavailable"}), 503
+
+    payload = request.get_json(silent=True) or {}
+    record_id_raw = payload.get("id")
+    record_id = str(record_id_raw).strip() if isinstance(record_id_raw, str) else ""
+    if not record_id:
+        return jsonify({"error": "id_required"}), 400
+
+    action_raw = payload.get("action")
+    action = str(action_raw).strip() if isinstance(action_raw, str) else "included"
+
+    if not service.confirm(record_id, action=action or "included"):
+        return jsonify({"error": "not_found"}), 404
+
+    return jsonify({"ok": True, "id": record_id, "action": action or "included"}), 200
+
+
+__all__ = ["bp"]
+

--- a/backend/app/services/local_discovery.py
+++ b/backend/app/services/local_discovery.py
@@ -1,0 +1,361 @@
+"""Local filesystem discovery service."""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+import uuid
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from bs4 import BeautifulSoup
+from pdfminer.high_level import extract_text as pdf_extract_text
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_EXTENSIONS = {
+    ".pdf",
+    ".txt",
+    ".md",
+    ".markdown",
+    ".html",
+    ".htm",
+}
+
+MAX_TEXT_LENGTH = 750_000
+PREVIEW_LENGTH = 400
+
+
+@dataclass(slots=True)
+class DiscoveryRecord:
+    """In-memory representation of a discovered document."""
+
+    id: str
+    path: str
+    name: str
+    ext: str
+    size: int
+    mtime: float
+    created_at: float
+    text: str
+    preview: str
+
+
+class _DirectoryEventHandler(FileSystemEventHandler):
+    """Watchdog handler that forwards file events to the service."""
+
+    def __init__(self, service: "LocalDiscoveryService") -> None:
+        self._service = service
+
+    def on_created(self, event: FileSystemEvent) -> None:  # pragma: no cover - watchdog glue
+        if event.is_directory:
+            return
+        self._service.enqueue(Path(event.src_path))
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # pragma: no cover - watchdog glue
+        if event.is_directory:
+            return
+        self._service.enqueue(Path(event.src_path))
+
+    def on_moved(self, event: FileSystemEvent) -> None:  # pragma: no cover - watchdog glue
+        if event.is_directory:
+            return
+        self._service.enqueue(Path(event.dest_path))
+
+
+class LocalDiscoveryService:
+    """Monitor local directories for newly downloaded documents."""
+
+    def __init__(self, directories: Iterable[Path], ledger_path: Path) -> None:
+        self._directories = [directory.resolve() for directory in directories]
+        self._ledger_path = ledger_path
+        self._lock = threading.RLock()
+        self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="local-discovery")
+        self._observer: Optional[Observer] = None
+        self._pending: Dict[str, DiscoveryRecord] = {}
+        self._archive: Dict[str, DiscoveryRecord] = {}
+        self._subscribers: Dict[str, queue.Queue[DiscoveryRecord | None]] = {}
+        self._confirmations: Dict[str, Dict[str, Any]] = {}
+        self._confirmed_ids: set[str] = set()
+        self._seen_mtimes: Dict[str, float] = {}
+        self._started = False
+        self._load_confirmations()
+
+    # ------------------------------------------------------------------
+    # Lifecycle management
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start watchdog observers (idempotent)."""
+
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+
+        for directory in self._directories:
+            directory.mkdir(parents=True, exist_ok=True)
+
+        observer = Observer()
+        handler = _DirectoryEventHandler(self)
+        for directory in self._directories:
+            observer.schedule(handler, str(directory), recursive=False)
+            LOGGER.debug("Local discovery watching %s", directory)
+
+        observer.start()
+        self._observer = observer
+
+        # Scan existing files once to surface any pending documents.
+        for directory in self._directories:
+            self.scan(directory)
+
+    def stop(self) -> None:
+        """Stop observers and worker threads."""
+
+        with self._lock:
+            self._started = False
+
+        if self._observer is not None:
+            try:
+                self._observer.stop()
+                self._observer.join(timeout=5)
+            except Exception:  # pragma: no cover - defensive shutdown
+                LOGGER.exception("Failed to stop local discovery observer")
+            finally:
+                self._observer = None
+
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+        for subscriber_id in list(self._subscribers):
+            self.unsubscribe(subscriber_id)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def enqueue(self, path: Path) -> None:
+        """Schedule *path* for processing."""
+
+        resolved = path.resolve()
+        if not resolved.exists():
+            return
+        self._executor.submit(self._process_with_retries, resolved)
+
+    def scan(self, directory: Path) -> None:
+        """Eagerly scan *directory* for supported files."""
+
+        try:
+            entries = list(directory.iterdir())
+        except OSError:
+            return
+
+        for entry in entries:
+            if entry.is_file():
+                self.enqueue(entry)
+
+    def subscribe(self) -> tuple[str, queue.Queue[DiscoveryRecord | None]]:
+        """Register an SSE subscriber."""
+
+        token = uuid.uuid4().hex
+        stream: queue.Queue[DiscoveryRecord | None] = queue.Queue()
+        with self._lock:
+            self._subscribers[token] = stream
+            for record in self._pending.values():
+                stream.put(record)
+        return token, stream
+
+    def unsubscribe(self, token: str) -> None:
+        with self._lock:
+            stream = self._subscribers.pop(token, None)
+        if stream is not None:
+            stream.put(None)
+
+    def list_pending(self) -> list[DiscoveryRecord]:
+        with self._lock:
+            return list(self._pending.values())
+
+    def get(self, record_id: str) -> Optional[DiscoveryRecord]:
+        with self._lock:
+            record = self._pending.get(record_id) or self._archive.get(record_id)
+        return record
+
+    def confirm(self, record_id: str, *, action: str = "included") -> bool:
+        """Mark *record_id* as handled."""
+
+        normalized = action.strip().lower() or "included"
+        with self._lock:
+            if record_id in self._confirmed_ids:
+                return True
+            record = self._pending.pop(record_id, None)
+            if record is None:
+                record = self._archive.get(record_id)
+            if record is None:
+                return False
+            self._archive[record_id] = record
+            self._confirmed_ids.add(record_id)
+            self._confirmations[record.path] = {
+                "mtime": record.mtime,
+                "action": normalized,
+                "confirmed_at": time.time(),
+            }
+            self._save_confirmations()
+        return True
+
+    def to_dict(self, record: DiscoveryRecord, *, include_text: bool) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "id": record.id,
+            "path": record.path,
+            "name": record.name,
+            "ext": record.ext,
+            "size": record.size,
+            "mtime": record.mtime,
+            "createdAt": record.created_at,
+            "preview": record.preview,
+        }
+        if include_text:
+            payload["text"] = record.text
+        return payload
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _process_with_retries(self, path: Path) -> None:
+        time.sleep(0.5)
+        for attempt in range(3):
+            try:
+                processed = self._process_path(path)
+            except Exception:  # pragma: no cover - logged
+                LOGGER.exception("Local discovery failed for %s", path)
+                return
+            if processed:
+                return
+            time.sleep(0.5)
+
+    def _process_path(self, path: Path) -> bool:
+        if not path.exists():
+            return False
+        ext = path.suffix.lower()
+        if ext not in SUPPORTED_EXTENSIONS:
+            return False
+
+        try:
+            stat = path.stat()
+        except OSError:
+            return False
+
+        path_str = str(path)
+        mtime = stat.st_mtime
+
+        with self._lock:
+            confirmation = self._confirmations.get(path_str)
+            if confirmation and float(confirmation.get("mtime", 0)) >= mtime:
+                return False
+            seen = self._seen_mtimes.get(path_str)
+            if seen and seen >= mtime:
+                return False
+            for record in self._pending.values():
+                if record.path == path_str:
+                    return False
+
+        text = self._extract_text(path, ext)
+        if not text:
+            return False
+
+        trimmed = text[:MAX_TEXT_LENGTH]
+        preview = trimmed[:PREVIEW_LENGTH].strip()
+
+        record = DiscoveryRecord(
+            id=self._make_record_id(path_str, mtime),
+            path=path_str,
+            name=path.name,
+            ext=ext.lstrip("."),
+            size=stat.st_size,
+            mtime=mtime,
+            created_at=time.time(),
+            text=trimmed,
+            preview=preview,
+        )
+
+        with self._lock:
+            self._pending[record.id] = record
+            self._archive[record.id] = record
+            self._seen_mtimes[path_str] = mtime
+            subscribers = list(self._subscribers.values())
+
+        for stream in subscribers:
+            stream.put(record)
+
+        LOGGER.info("Discovered local file: %s", path_str)
+        return True
+
+    def _extract_text(self, path: Path, ext: str) -> str:
+        try:
+            if ext in {".txt", ".md", ".markdown"}:
+                return path.read_text(encoding="utf-8", errors="ignore")
+            if ext in {".html", ".htm"}:
+                raw = path.read_text(encoding="utf-8", errors="ignore")
+                soup = BeautifulSoup(raw, "html.parser")
+                for tag in soup(["script", "style", "noscript"]):
+                    tag.decompose()
+                text = soup.get_text("\n")
+                return text
+            if ext == ".pdf":
+                return pdf_extract_text(str(path))
+        except Exception:  # pragma: no cover - logged by caller
+            raise
+        return ""
+
+    def _make_record_id(self, path: str, mtime: float) -> str:
+        return uuid.uuid5(uuid.NAMESPACE_URL, f"{path}:{mtime}").hex
+
+    def _load_confirmations(self) -> None:
+        try:
+            raw = self._ledger_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        except OSError:  # pragma: no cover - defensive
+            LOGGER.exception("Unable to read local discovery ledger")
+            return
+
+        try:
+            payload = json.loads(raw)
+        except ValueError:  # pragma: no cover - defensive
+            LOGGER.warning("Invalid JSON in local discovery ledger: %s", self._ledger_path)
+            return
+
+        if not isinstance(payload, dict):
+            return
+
+        entries = payload.get("paths")
+        if not isinstance(entries, dict):
+            return
+
+        for path_str, entry in entries.items():
+            if not isinstance(path_str, str) or not isinstance(entry, dict):
+                continue
+            mtime = float(entry.get("mtime", 0))
+            action = str(entry.get("action", "included"))
+            confirmed_at = float(entry.get("confirmed_at", time.time()))
+            self._confirmations[path_str] = {
+                "mtime": mtime,
+                "action": action,
+                "confirmed_at": confirmed_at,
+            }
+
+    def _save_confirmations(self) -> None:
+        data = {"paths": self._confirmations}
+        self._ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._ledger_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        tmp_path.replace(self._ledger_path)
+
+
+__all__ = ["LocalDiscoveryService", "DiscoveryRecord"]
+

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 # Optional override: point the Next.js app at a specific API origin
 NEXT_PUBLIC_API_BASE_URL=
 NEXT_PUBLIC_API_BASE=
+NEXT_PUBLIC_FEATURE_LOCAL_DISCOVERY=true

--- a/frontend/src/components/local-discovery-panel.tsx
+++ b/frontend/src/components/local-discovery-panel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import type { DiscoveryPreview } from "@/lib/types";
+
+interface LocalDiscoveryPanelProps {
+  items: DiscoveryPreview[];
+  busyIds: Set<string>;
+  onInclude: (id: string) => void;
+  onDismiss: (id: string) => void;
+}
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function formatTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "";
+  const date = new Date(seconds * 1000);
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function LocalDiscoveryPanel({ items, busyIds, onInclude, onDismiss }: LocalDiscoveryPanelProps) {
+  const sorted = useMemo(() => {
+    return [...items].sort((a, b) => b.createdAt - a.createdAt);
+  }, [items]);
+
+  if (sorted.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-40 flex w-96 max-w-full flex-col gap-3">
+      {sorted.map((item) => {
+        const busy = busyIds.has(item.id);
+        const detectedAt = formatTimestamp(item.createdAt);
+        return (
+          <div
+            key={item.id}
+            className="pointer-events-auto space-y-3 rounded-md border border-foreground/15 bg-background/95 p-4 shadow-lg"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-2 text-sm">
+                <div className="space-y-1">
+                  <p className="font-medium">Found file: {item.name}</p>
+                  <p className="break-words text-xs text-muted-foreground">{item.path}</p>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {item.ext.toUpperCase()} · {formatFileSize(item.size)}
+                  {detectedAt ? ` · Detected ${detectedAt}` : ""}
+                </p>
+                {item.preview ? (
+                  <p className="line-clamp-3 text-xs text-muted-foreground">{item.preview}</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Text extracted and ready to index.</p>
+                )}
+              </div>
+              <div className="flex flex-col gap-2 text-xs">
+                <Button size="sm" onClick={() => onInclude(item.id)} disabled={busy}>
+                  {busy ? "Including…" : "Include"}
+                </Button>
+                <button
+                  type="button"
+                  className="text-muted-foreground transition hover:text-foreground"
+                  onClick={() => onDismiss(item.id)}
+                  disabled={busy}
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -197,3 +197,18 @@ export interface ShadowStatus {
   updatedAt?: number;
   updated_at?: number;
 }
+
+export interface DiscoveryPreview {
+  id: string;
+  path: string;
+  name: string;
+  ext: string;
+  size: number;
+  mtime: number;
+  createdAt: number;
+  preview: string;
+}
+
+export interface DiscoveryItem extends DiscoveryPreview {
+  text: string;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ beautifulsoup4==4.12.3
 lxml==5.3.0
 tiktoken==0.7.0
 numpy==1.26.4
+watchdog==4.0.1
+pdfminer.six==20231228

--- a/tests/backend/test_local_discovery.py
+++ b/tests/backend/test_local_discovery.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from backend.app.services.local_discovery import LocalDiscoveryService
+
+
+def test_local_discovery_processing_and_confirmation(tmp_path):
+    downloads = tmp_path / "downloads"
+    downloads.mkdir()
+    ledger_path = tmp_path / "ledger.json"
+
+    path = downloads / "example.txt"
+
+    service = LocalDiscoveryService([downloads], ledger_path)
+    try:
+        path.write_text("hello world", encoding="utf-8")
+
+        assert service._process_path(path)  # type: ignore[attr-defined]
+
+        pending = service.list_pending()
+        assert len(pending) == 1
+        record = pending[0]
+        assert record.path == str(path)
+        assert "hello world" in record.text
+
+        assert service.confirm(record.id, action="included")
+    finally:
+        service.stop()
+
+    assert ledger_path.exists()
+    payload = json.loads(ledger_path.read_text(encoding="utf-8"))
+    key = str(path)
+    assert key in payload["paths"]
+
+    # Confirmed files are ignored when the service is reloaded.
+    service2 = LocalDiscoveryService([downloads], ledger_path)
+    try:
+        path.write_text("hello world", encoding="utf-8")
+        assert not service2._process_path(path)  # type: ignore[attr-defined]
+    finally:
+        service2.stop()


### PR DESCRIPTION
## Summary
- add a watchdog-backed local discovery service with SSE APIs and feature flag wiring
- surface discovery notifications in the frontend with include/dismiss flows that index approved files
- document the feature, expose the new env flag, and add targeted test coverage plus dependencies

## Testing
- pytest tests/backend/test_local_discovery.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4c7bfb1c832197281c64d5091288