### PR TITLE
Add experimental allowed dev origins to Next config

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,4 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+const baseConfig = {
   async rewrites() {
     return [
       {
@@ -7,6 +6,17 @@ const nextConfig = {
         destination: "http://127.0.0.1:5050/api/:path*",
       },
     ];
+  },
+};
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  ...baseConfig,
+  experimental: {
+    allowedDevOrigins: [
+      "http://localhost:3100",
+      "http://127.0.0.1:3100",
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary
- add experimental `allowedDevOrigins` entries for localhost:3100 and 127.0.0.1:3100
- ensure existing rewrites remain by exporting a combined Next.js config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dddd8f600483219b6e3fe8ec7ae9b5