### PR TITLE
Improve agent fallback candidate selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ _MAIN_0.toc
 !tests/api/test_shadow_api.py
 !tests/e2e/test_agent_browser.py
 !tests/backend/test_local_discovery.py
+!tests/backend/test_agent_runtime.py

--- a/docs/agent_runtime.md
+++ b/docs/agent_runtime.md
@@ -1,0 +1,23 @@
+# Agent runtime discovery fallbacks
+
+The agent runtime builds crawl candidates from multiple sources whenever a query
+returns too few local results. The fallback flow prioritizes previously seen
+content and curated entrypoints to keep discovery relevant and policy compliant:
+
+1. **Search hits** – Any URLs returned from the vector/BM25 search path are
+   sanitized and deduplicated before being queued.
+2. **Recent discoveries** – If no hits are available, the runtime scans the
+   document store for the most recently saved pages and reuses those canonical
+   URLs. This allows fresh crawl results to bootstrap subsequent turns.
+3. **Seed registry suggestions** – Curated registry entrypoints
+   (`seeds/registry.yaml`) are loaded and scored using tag, strategy, and trust
+   metadata. High-trust feeds and Wikipedia portals surface first, ensuring that
+   crawl work always starts from vetted domains.
+4. **Domain heuristics** – Finally, deterministic heuristics derive topical
+   targets such as Wikipedia articles and evergreen research hubs using the
+   original query text.
+
+Every candidate is normalized to an allowed HTTP(S) URL before enqueueing the
+frontier. This keeps the crawl queue free of unsupported schemes or duplicate
+entries while still guaranteeing that each fallback list contains actionable,
+real-world targets for cold-start scenarios.

--- a/tests/backend/test_agent_runtime.py
+++ b/tests/backend/test_agent_runtime.py
@@ -1,0 +1,90 @@
+"""Unit tests for the agent runtime fallback discovery heuristics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.agent.document_store import DocumentStore, StoredDocument
+from backend.agent.frontier_store import FrontierStore
+from backend.agent.runtime import AgentRuntime, FetcherProtocol
+
+
+class _VectorIndexStub:
+    def search(self, *_args, **_kwargs):  # pragma: no cover - unused in these tests
+        return []
+
+    def metadata(self):  # pragma: no cover - unused in these tests
+        return {}
+
+    def upsert_document(self, **_kwargs):  # pragma: no cover - unused in these tests
+        class _Result:
+            chunks = 0
+
+        return _Result()
+
+
+class _FetcherStub(FetcherProtocol):
+    def fetch(self, url: str):  # pragma: no cover - unused in these tests
+        raise RuntimeError(f"unexpected fetch call for {url}")
+
+
+@pytest.fixture
+def runtime(tmp_path: Path) -> AgentRuntime:
+    frontier = FrontierStore(tmp_path / "frontier.sqlite3")
+    store = DocumentStore(tmp_path / "docs")
+    vector_index = _VectorIndexStub()
+    fetcher = _FetcherStub()
+    return AgentRuntime(
+        search_service=None,
+        frontier=frontier,
+        document_store=store,
+        vector_index=vector_index,
+        fetcher=fetcher,
+    )
+
+
+def test_candidate_urls_filters_invalid_hits(runtime: AgentRuntime) -> None:
+    hits = [
+        {"url": "https://example.com/path"},
+        {"url": "HTTPS://EXAMPLE.com/path"},
+        {"url": "ftp://example.com/resource"},
+        {"url": "javascript:alert(1)"},
+    ]
+
+    candidates = runtime._candidate_urls("ignored", hits)
+
+    assert candidates == ["https://example.com/path"]
+
+
+def test_candidate_urls_fallback_runtime_sources(runtime: AgentRuntime, tmp_path: Path) -> None:
+    doc = StoredDocument(
+        url="https://docs.example.com/guide",
+        title="Guide",
+        text="Example body",
+        sha256="abc123",
+    )
+    runtime.document_store.save(doc)
+
+    candidates = runtime._candidate_urls("quantum computing", [])
+
+    assert "https://docs.example.com/guide" in candidates
+
+    from server.seeds_loader import load_seed_registry
+
+    registry_urls = {
+        url
+        for entry in load_seed_registry()
+        for url in entry.entrypoints
+    }
+    assert registry_urls.intersection(candidates)
+
+    heuristic_expected = "https://en.wikipedia.org/wiki/Quantum_Computing"
+    assert heuristic_expected in candidates
+
+
+def test_candidate_urls_fallback_is_deterministic(runtime: AgentRuntime) -> None:
+    first = runtime._candidate_urls("open source intelligence", [])
+    second = runtime._candidate_urls("open source intelligence", [])
+    assert first == second


### PR DESCRIPTION
## Summary
- replace the agent runtime's placeholder candidate builder with curated fallbacks that reuse recent documents, seed registry entrypoints, and deterministic heuristics while enforcing crawl policies
- document the discovery fallback order for developers and add unit tests covering empty-hit scenarios and URL normalization

## Testing
- pytest tests/backend/test_agent_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68de00646220832191ec46971e02dd4c