### PR TITLE
Fix chat timestamps to avoid hydration mismatch

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -117,7 +117,7 @@ const DEFAULT_CHAT_MESSAGES: ChatMessage[] = [
     role: "assistant",
     content:
       "Welcome! Paste a URL or ask me to search. I will only crawl when you approve each step.",
-    createdAt: new Date().toISOString(),
+    createdAt: "",
   },
 ];
 
@@ -236,6 +236,22 @@ export function AppShell() {
 
   useEffect(() => {
     devlog({ evt: "ui.mount" });
+  }, []);
+
+  useEffect(() => {
+    setChatMessages((messages) => {
+      if (messages.length === 0) {
+        return messages;
+      }
+
+      const [first, ...rest] = messages;
+      const timestamp = typeof first.createdAt === "string" ? first.createdAt.trim() : "";
+      if (timestamp && !Number.isNaN(new Date(timestamp).getTime())) {
+        return messages;
+      }
+
+      return [{ ...first, createdAt: new Date().toISOString() }, ...rest];
+    });
   }, []);
 
   const navigateTo = useCallback(

--- a/frontend/src/components/chat-panel.tsx
+++ b/frontend/src/components/chat-panel.tsx
@@ -27,10 +27,20 @@ interface ChatPanelProps {
 }
 
 function formatTimestamp(value: string) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) {
+    return "";
+  }
+
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
   try {
-    return new Date(value).toLocaleTimeString();
+    return date.toLocaleTimeString();
   } catch {
-    return value;
+    return "";
   }
 }
 


### PR DESCRIPTION
## Summary
- make the default assistant welcome message timestamp deterministic for consistent SSR markup
- hydrate blank initial timestamps on mount to maintain real chat metadata
- guard chat timestamp formatting against placeholder values to avoid client/server mismatch

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68de02382d0883219cfe795ed2b7d32a