### PR TITLE
Allow configuring frontend API proxy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,12 @@ dev:
 	@echo "▶ Starting Frontend (Next.js)…"
 	@if ! lsof -iTCP:$(FRONTEND_PORT) -sTCP:LISTEN >/dev/null 2>&1; then \
 	  mkdir -p logs; \
-	  (cd frontend && nohup npm run dev -- --hostname 0.0.0.0 --port $(FRONTEND_PORT) > ../logs/frontend.log 2>&1 & echo $$! > ../logs/frontend.pid) ; \
+	  (cd frontend && \
+	    if [ -z "$$NEXT_PUBLIC_API_BASE_URL" ]; then \
+	      export NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:$(BACKEND_PORT); \
+	    fi; \
+	    nohup npm run dev -- --hostname 0.0.0.0 --port $(FRONTEND_PORT) > ../logs/frontend.log 2>&1 & echo $$! > ../logs/frontend.pid \
+	  ) ; \
 	fi
 	@echo "✅ UI http://127.0.0.1:$(FRONTEND_PORT)  |  API http://127.0.0.1:$(BACKEND_PORT)"
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ make dev
   already exists) and starts the Next.js dev server (binds to `0.0.0.0` and is
   reachable at `http://localhost:3100`; override with `FRONTEND_PORT`). Point
   your browser at `http://localhost:3100`; all `/api/*` calls proxy to the
-  Flask API at `http://127.0.0.1:5050`.
+  Flask API at the URL derived from `NEXT_PUBLIC_API_BASE_URL` (defaults to
+  `http://127.0.0.1:${BACKEND_PORT}` with a fallback of `5050`).
 - Streams frontend dev instrumentation (via `/api/dev/log`) into the backend
   terminal so you can observe chat/search actions alongside Flask logs.
 - Tears both processes down when either exits or you press
@@ -140,8 +141,9 @@ without hunting for process IDs.
 Open the browser at `http://localhost:3100` to use the UI. Make sure `ollama`
 is listening on `http://127.0.0.1:11434` (or adjust `OLLAMA_HOST`). If
 `localhost:5050` is busy (macOS ships AirPlay on that port), run
-`BACKEND_PORT=5051 make dev` instead. The Flask API root now returns a JSON ping
-to confirm the service is API-only and that the UI lives entirely in Next.js.
+`BACKEND_PORT=5051 make dev` instead; the proxy will automatically follow the
+updated port. The Flask API root now returns a JSON ping to confirm the service
+is API-only and that the UI lives entirely in Next.js.
 
 Verify the stack after startup with:
 
@@ -168,7 +170,8 @@ BACKEND_RELOAD=1 make run
 ```
 
 Launch the frontend in a separate terminal (remember to export
-`NEXT_PUBLIC_API_BASE_URL` when pointing at a remote API):
+`NEXT_PUBLIC_API_BASE_URL` when pointing at a remote API — omit it to follow
+`BACKEND_PORT` locally):
 
 ```bash
 cd frontend

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,9 +1,25 @@
+const API_BASE_URL = (() => {
+  const explicit = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (explicit && explicit.trim().length > 0) {
+    return explicit;
+  }
+
+  const backendPort = process.env.BACKEND_PORT;
+  if (backendPort && backendPort.trim().length > 0) {
+    return `http://127.0.0.1:${backendPort}`;
+  }
+
+  return "http://127.0.0.1:5050";
+})();
+
+const normalizedApiBaseUrl = API_BASE_URL.replace(/\/$/, "");
+
 const baseConfig = {
   async rewrites() {
     return [
       {
         source: "/api/:path*",
-        destination: "http://127.0.0.1:5050/api/:path*",
+        destination: `${normalizedApiBaseUrl}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- derive the Next.js `/api` rewrite destination from `NEXT_PUBLIC_API_BASE_URL` or `BACKEND_PORT`, falling back to 127.0.0.1:5050
- export the resolved API base URL when launching `npm run dev` so `make dev` honors overridden backend ports
- document the new proxy behavior and local override guidance in the README

## Testing
- BACKEND_PORT=5051 make dev
- API_BASE=http://127.0.0.1:5051 UI_BASE=http://127.0.0.1:3100 ./scripts/dev_verify.sh | fold -w 120
- make stop

------
https://chatgpt.com/codex/tasks/task_e_68de05ed74c88321816b6f7f369aafe8