### PR TITLE
Add LangSmith tracing instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,28 @@ invoking the relevant Make target (see `Makefile` for the full list). Fast local
 storage is strongly recommended because the Flask app and background workers
 share the same directories.
 
+## LangSmith tracing
+
+End-to-end traces are emitted via LangSmith + OpenTelemetry when
+`LANGSMITH_ENABLED=true` is present in the environment. The integration uses the
+official LangSmith Python SDK and reports spans for the focused crawl pipeline
+(`crawl → normalize → index → query`), HTTP endpoints (`/api/search`,
+`/api/tools/reindex`, `/api/chat`, `/api/search/crawl`), retrieval calls (Whoosh
+and Chroma), and LLM invocations (Ollama chat, embeddings, rerank).
+
+Set the following variables in your shell or `.env` file to enable tracing:
+
+```bash
+export LANGSMITH_ENABLED=true
+export LANGSMITH_API_KEY=...        # issued from app.langchain.com
+export LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+export LANGSMITH_PROJECT="self-hosted-search"  # optional override
+```
+
+When disabled (the default), tracing imports are no-ops. Errors automatically
+record the exception class and redact sensitive inputs using the existing
+logging sanitiser.
+
 ## Testing & quality gates
 
 The repository ships with an opinionated pre-flight suite. Run it before opening

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -23,6 +23,7 @@ from backend.app.api.seeds import parse_http_url
 from backend.logging_utils import event_base, redact, write_event
 from server.llm import LLMError
 from server.runlog import add_run_log_line, current_run_log
+from observability import start_span
 
 bp = Blueprint("search_api", __name__, url_prefix="/api")
 
@@ -249,147 +250,180 @@ def run_agent(
     user_id = getattr(g, "user_id", None)
     add_run_log_line(f"agent turn: {query[:80]}")
 
-    def _finalize(payload: dict[str, Any], *, status: str, message: str) -> dict[str, Any]:
-        if status == "ok":
-            add_run_log_line("agent turn complete")
-        else:
-            add_run_log_line(f"agent status={status}")
-        response_payload = dict(payload)
-        run_log = current_run_log()
-        if run_log is not None and "run_log" not in response_payload:
-            response_payload["run_log"] = run_log.dump()
-        meta_payload = dict(response_payload)
-        if isinstance(meta_payload.get("run_log"), list):
-            meta_payload["run_log"] = len(meta_payload["run_log"])
-        meta = {
-            "query": query,
-            "model_requested": model,
-            "response": meta_payload,
-        }
-        duration_ms = int((time.time() - start) * 1000)
-        write_event(
-            event_base(
-                event="agent.turn",
-                level="INFO" if status == "ok" else "ERROR",
-                status=status,
-                route=route,
-                request_id=request_id,
-                session_id=session_id,
-                user_id=user_id,
-                duration_ms=duration_ms,
-                msg=message,
-                meta=meta,
+    context_keys = sorted(str(key) for key in context.keys()) if context else None
+
+    with start_span(
+        "agent.turn",
+        attributes={"llm.model.requested": model or ""},
+        inputs={"query": query, "context_keys": context_keys},
+    ) as turn_span:
+
+        def _finalize(payload: dict[str, Any], *, status: str, message: str) -> dict[str, Any]:
+            if status == "ok":
+                add_run_log_line("agent turn complete")
+            else:
+                add_run_log_line(f"agent status={status}")
+            response_payload = dict(payload)
+            run_log = current_run_log()
+            if run_log is not None and "run_log" not in response_payload:
+                response_payload["run_log"] = run_log.dump()
+            meta_payload = dict(response_payload)
+            if isinstance(meta_payload.get("run_log"), list):
+                meta_payload["run_log"] = len(meta_payload["run_log"])
+            meta = {
+                "query": query,
+                "model_requested": model,
+                "response": meta_payload,
+            }
+            duration_ms = int((time.time() - start) * 1000)
+            write_event(
+                event_base(
+                    event="agent.turn",
+                    level="INFO" if status == "ok" else "ERROR",
+                    status=status,
+                    route=route,
+                    request_id=request_id,
+                    session_id=session_id,
+                    user_id=user_id,
+                    duration_ms=duration_ms,
+                    msg=message,
+                    meta=meta,
+                )
             )
+            if turn_span is not None:
+                turn_span.set_attribute("agent.status", status)
+                turn_span.set_attribute("agent.duration_ms", duration_ms)
+                if isinstance(payload.get("actions"), Sequence):
+                    turn_span.set_attribute("agent.actions", len(payload.get("actions", [])))
+            return response_payload
+
+        planner = current_app.config.get("RAG_PLANNER_AGENT")
+        if planner is None:
+            payload = _warming_payload(
+                "Planner agent unavailable.",
+                code="planner_unavailable",
+                candidates=[],
+            )
+            payload["llm_used"] = True
+            if model:
+                payload["llm_model"] = model
+            return _finalize(payload, status="error", message="planner unavailable")
+
+        engine_config: EngineConfig | None = current_app.config.get("RAG_ENGINE_CONFIG")
+        embedder: OllamaEmbedder | None = current_app.config.get("RAG_EMBEDDER")
+        embed_manager: EmbeddingManager | None = current_app.config.get("RAG_EMBED_MANAGER")
+        embed_model_name = (
+            current_app.config.get("RAG_EMBED_MODEL_NAME")
+            if current_app.config.get("RAG_EMBED_MODEL_NAME")
+            else (engine_config.models.embed if engine_config else None)
+        ) or "embeddinggemma"
+
+        if embedder is None:
+            payload = _warming_payload(
+                "Embedding pipeline unavailable.",
+                code="embedder_unavailable",
+                candidates=[],
+            )
+            payload["llm_used"] = True
+            if model:
+                payload["llm_model"] = model
+            return _finalize(payload, status="error", message="embedder unavailable")
+
+        ready, _, status, detail = _ensure_embedder_ready(
+            embed_manager, embedder, embed_model_name
         )
-        return response_payload
+        if not ready:
+            payload = _embedding_unavailable_payload(
+                detail or "Embedding model unavailable.", status=status
+            )
+            payload["llm_used"] = True
+            if model:
+                payload["llm_model"] = model
+            return _finalize(payload, status="error", message="embedding not ready")
 
-    planner = current_app.config.get("RAG_PLANNER_AGENT")
-    if planner is None:
-        payload = _warming_payload(
-            "Planner agent unavailable.",
-            code="planner_unavailable",
-            candidates=[],
+        planner_context: dict[str, Any] = {}
+        if engine_config is not None:
+            planner_context["retrieval"] = {
+                "k": engine_config.retrieval.k,
+                "similarity_threshold": engine_config.retrieval.similarity_threshold,
+            }
+        if context:
+            planner_context.update({str(k): v for k, v in context.items()})
+
+        try:
+            with start_span(
+                "agent.planner.execute",
+                attributes={
+                    "planner.class": planner.__class__.__name__,
+                    "llm.model.requested": model or "",
+                },
+                inputs={"query": query, "planner_context": planner_context},
+            ) as planner_span:
+                result = planner.run(query, context=planner_context, model=model)
+                if planner_span is not None and isinstance(result, Mapping):
+                    steps_payload = result.get("steps")
+                    if isinstance(steps_payload, Sequence):
+                        planner_span.set_attribute("agent.steps", len(steps_payload))
+        except LLMError as exc:
+            message = str(exc)[:200]
+            payload = {
+                "type": "final",
+                "answer": "Planner LLM is unavailable.",
+                "sources": [],
+                "actions": ["planner_unavailable"],
+                "planner_model_used": None,
+                "error": message,
+                "planner_models": _planner_model_candidates(planner, model),
+                "llm_used": True,
+            }
+            if model:
+                payload["llm_model_requested"] = model
+            return _finalize(payload, status="error", message="planner llm error")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            current_app.logger.exception("planner execution failed for query='%s'", query)
+            payload = {
+                "type": "final",
+                "answer": "Planner failed to complete request.",
+                "sources": [],
+                "actions": ["planner_error"],
+                "planner_model_used": None,
+                "error": str(exc)[:200],
+                "planner_models": _planner_model_candidates(planner, model),
+                "llm_used": True,
+            }
+            if model:
+                payload["llm_model_requested"] = model
+            return _finalize(payload, status="error", message="planner execution error")
+
+        response = dict(result)
+        used_model = response.get("planner_model_used")
+        response["llm_used"] = True
+        if model:
+            response["llm_model_requested"] = model
+        if used_model:
+            response.setdefault("llm_model", used_model)
+        elif model:
+            response.setdefault("llm_model", model)
+
+        steps = response.get("steps")
+        candidates = _collect_candidates_from_steps(
+            steps if isinstance(steps, Sequence) else None
         )
-        payload["llm_used"] = True
-        if model:
-            payload["llm_model"] = model
-        return _finalize(payload, status="error", message="planner unavailable")
+        if candidates:
+            response.setdefault("candidates", candidates)
+            response.setdefault("results", candidates)
 
-    engine_config: EngineConfig | None = current_app.config.get("RAG_ENGINE_CONFIG")
-    embedder: OllamaEmbedder | None = current_app.config.get("RAG_EMBEDDER")
-    embed_manager: EmbeddingManager | None = current_app.config.get("RAG_EMBED_MANAGER")
-    embed_model_name = (
-        current_app.config.get("RAG_EMBED_MODEL_NAME")
-        if current_app.config.get("RAG_EMBED_MODEL_NAME")
-        else (engine_config.models.embed if engine_config else None)
-    ) or "embeddinggemma"
+        summaries = _summarize_tool_steps(steps if isinstance(steps, Sequence) else None)
+        if summaries and current_app.logger.isEnabledFor(10):  # DEBUG
+            current_app.logger.debug(
+                "planner tool summary query='%s': %s", query, "; ".join(summaries)
+            )
+        if turn_span is not None and isinstance(steps, Sequence):
+            turn_span.set_attribute("agent.steps", len(steps))
+        if turn_span is not None and used_model:
+            turn_span.set_attribute("agent.llm_model", used_model)
 
-    if embedder is None:
-        payload = _warming_payload(
-            "Embedding pipeline unavailable.",
-            code="embedder_unavailable",
-            candidates=[],
-        )
-        payload["llm_used"] = True
-        if model:
-            payload["llm_model"] = model
-        return _finalize(payload, status="error", message="embedder unavailable")
-
-    ready, _, status, detail = _ensure_embedder_ready(
-        embed_manager, embedder, embed_model_name
-    )
-    if not ready:
-        payload = _embedding_unavailable_payload(detail or "Embedding model unavailable.", status=status)
-        payload["llm_used"] = True
-        if model:
-            payload["llm_model"] = model
-        return _finalize(payload, status="error", message="embedding not ready")
-
-    planner_context: dict[str, Any] = {}
-    if engine_config is not None:
-        planner_context["retrieval"] = {
-            "k": engine_config.retrieval.k,
-            "similarity_threshold": engine_config.retrieval.similarity_threshold,
-        }
-    if context:
-        planner_context.update({str(k): v for k, v in context.items()})
-
-    try:
-        result = planner.run(query, context=planner_context, model=model)
-    except LLMError as exc:
-        message = str(exc)[:200]
-        payload = {
-            "type": "final",
-            "answer": "Planner LLM is unavailable.",
-            "sources": [],
-            "actions": ["planner_unavailable"],
-            "planner_model_used": None,
-            "error": message,
-            "planner_models": _planner_model_candidates(planner, model),
-            "llm_used": True,
-        }
-        if model:
-            payload["llm_model_requested"] = model
-        return _finalize(payload, status="error", message="planner llm error")
-    except Exception as exc:  # pragma: no cover - defensive logging
-        current_app.logger.exception("planner execution failed for query='%s'", query)
-        payload = {
-            "type": "final",
-            "answer": "Planner failed to complete request.",
-            "sources": [],
-            "actions": ["planner_error"],
-            "planner_model_used": None,
-            "error": str(exc)[:200],
-            "planner_models": _planner_model_candidates(planner, model),
-            "llm_used": True,
-        }
-        if model:
-            payload["llm_model_requested"] = model
-        return _finalize(payload, status="error", message="planner execution error")
-
-    response = dict(result)
-    used_model = response.get("planner_model_used")
-    response["llm_used"] = True
-    if model:
-        response["llm_model_requested"] = model
-    if used_model:
-        response.setdefault("llm_model", used_model)
-    elif model:
-        response.setdefault("llm_model", model)
-
-    steps = response.get("steps")
-    candidates = _collect_candidates_from_steps(steps if isinstance(steps, Sequence) else None)
-    if candidates:
-        response.setdefault("candidates", candidates)
-        response.setdefault("results", candidates)
-
-    summaries = _summarize_tool_steps(steps if isinstance(steps, Sequence) else None)
-    if summaries and current_app.logger.isEnabledFor(10):  # DEBUG
-        current_app.logger.debug(
-            "planner tool summary query='%s': %s", query, "; ".join(summaries)
-        )
-
-    return _finalize(response, status="ok", message="agent turn ok")
+        return _finalize(response, status="ok", message="agent turn ok")
 
 
 def _planner_model_candidates(planner: Any, requested: str | None) -> list[str]:
@@ -445,28 +479,37 @@ def embedder_ensure_endpoint():
 @bp.post("/crawl")
 def crawl_validation_endpoint():
     payload = request.get_json(silent=True) or {}
-    url_value = payload.get("url")
-    if not isinstance(url_value, str) or not url_value.strip():
-        return jsonify({"error": "url is required"}), 400
-    try:
-        parsed = parse_http_url(url_value)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
+    inputs = {"url": payload.get("url"), "depth": payload.get("depth")}
+    with start_span(
+        "http.crawl.validate",
+        attributes={
+            "http.route": "/api/crawl",
+            "http.method": request.method,
+        },
+        inputs=inputs,
+    ):
+        url_value = payload.get("url")
+        if not isinstance(url_value, str) or not url_value.strip():
+            return jsonify({"error": "url is required"}), 400
+        try:
+            parsed = parse_http_url(url_value)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
-    depth_value = payload.get("depth", 1)
-    try:
-        depth = max(1, int(depth_value))
-    except (TypeError, ValueError):
-        return jsonify({"error": "depth must be a positive integer"}), 400
+        depth_value = payload.get("depth", 1)
+        try:
+            depth = max(1, int(depth_value))
+        except (TypeError, ValueError):
+            return jsonify({"error": "depth must be a positive integer"}), 400
 
-    normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path or "", "", parsed.query, ""))
-    response = {
-        "url": normalized.rstrip("/"),
-        "depth": depth,
-        "queued": False,
-        "detail": "URL validated; queue long-running crawls via /api/seeds or the Crawl Manager UI.",
-    }
-    return jsonify(response)
+        normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path or "", "", parsed.query, ""))
+        response = {
+            "url": normalized.rstrip("/"),
+            "depth": depth,
+            "queued": False,
+            "detail": "URL validated; queue long-running crawls via /api/seeds or the Crawl Manager UI.",
+        }
+        return jsonify(response)
 
 
 @bp.get("/search")
@@ -477,248 +520,263 @@ def search_endpoint():
 
     llm_enabled = _normalize_bool(request.args.get("llm"))
     llm_model = (request.args.get("model") or "").strip() or None
+    with start_span(
+        "http.search",
+        attributes={
+            "http.route": "/api/search",
+            "http.method": request.method,
+            "llm.enabled": bool(llm_enabled),
+        },
+        inputs={"query": query, "model": llm_model},
+    ) as span:
+        if llm_enabled:
+            agent_payload = run_agent(query, model=llm_model)
+            if span is not None:
+                span.set_attribute("search.mode", "agent")
+            return jsonify(agent_payload)
 
-    if llm_enabled:
-        agent_payload = run_agent(query, model=llm_model)
-        return jsonify(agent_payload)
+        engine_config: EngineConfig | None = current_app.config.get("RAG_ENGINE_CONFIG")
+        store = current_app.config.get("RAG_VECTOR_STORE")
+        embedder = current_app.config.get("RAG_EMBEDDER")
+        coldstart = current_app.config.get("RAG_COLDSTART")
+        rag_agent = current_app.config.get("RAG_AGENT")
+        embed_manager: EmbeddingManager | None = current_app.config.get("RAG_EMBED_MANAGER")
 
-    engine_config: EngineConfig | None = current_app.config.get("RAG_ENGINE_CONFIG")
-    store = current_app.config.get("RAG_VECTOR_STORE")
-    embedder = current_app.config.get("RAG_EMBEDDER")
-    coldstart = current_app.config.get("RAG_COLDSTART")
-    rag_agent = current_app.config.get("RAG_AGENT")
-    embed_manager: EmbeddingManager | None = current_app.config.get("RAG_EMBED_MANAGER")
+        rag_components_ready = all(component is not None for component in (store, embedder, coldstart, rag_agent))
 
-    rag_components_ready = all(component is not None for component in (store, embedder, coldstart, rag_agent))
+        if engine_config is None or not rag_components_ready:
+            search_service = current_app.config.get("SEARCH_SERVICE")
+            app_config = current_app.config.get("APP_CONFIG")
+            if search_service and app_config:
+                results, job_id, context = search_service.run_query(
+                    query,
+                    limit=app_config.search_default_limit,
+                    use_llm=llm_enabled,
+                    model=llm_model,
+                )
+                payload = {
+                    "status": "ok",
+                    "results": results,
+                    "llm_used": bool(llm_enabled),
+                }
+                if span is not None:
+                    span.set_attribute("search.results", len(results))
+                    if job_id:
+                        span.set_attribute("search.focused_job", True)
+                if context:
+                    payload["confidence"] = context.get("confidence")
+                    if context.get("trigger_reason"):
+                        payload["trigger_reason"] = context.get("trigger_reason")
+                    if context.get("seed_count"):
+                        payload["seed_count"] = context.get("seed_count")
+                if job_id:
+                    payload["job_id"] = job_id
+                    payload["last_index_time"] = search_service.last_index_time()
+                    if len(results) < app_config.smart_min_results or context.get("trigger_reason") == "low_confidence":
+                        payload["status"] = "focused_crawl_running"
+                if llm_model:
+                    payload["llm_model"] = llm_model
+            return jsonify(payload)
+        else:
+            store = cast(VectorStore, store)
+            embedder = cast(OllamaEmbedder, embedder)
+            coldstart = cast(ColdStartIndexer, coldstart)
+            rag_agent = cast(RagAgent, rag_agent)
 
-    if engine_config is None or not rag_components_ready:
-        search_service = current_app.config.get("SEARCH_SERVICE")
-        app_config = current_app.config.get("APP_CONFIG")
-        if search_service and app_config:
-            results, job_id, context = search_service.run_query(
-                query,
-                limit=app_config.search_default_limit,
-                use_llm=llm_enabled,
-                model=llm_model,
+            embed_model_name = (
+                current_app.config.get("RAG_EMBED_MODEL_NAME") or engine_config.models.embed
             )
+
+            ready, embed_model_name, embed_status, detail = _ensure_embedder_ready(
+                embed_manager, embedder, embed_model_name
+            )
+            if not ready:
+                payload = _embedding_unavailable_payload(
+                    detail or "Embedding model is not ready.", status=embed_status
+                )
+                payload["llm_used"] = llm_enabled
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
+            try:
+                query_vector = embedder.embed_query(query)
+            except EmbeddingError as exc:
+                message = (
+                    "Unable to generate embeddings from Ollama. "
+                    f"Ensure the model '{embed_model_name}' is installed and running."
+                )
+                payload = _embedding_unavailable_payload(
+                    f"{message} ({exc})", status=embed_status
+                )
+                payload["llm_used"] = llm_enabled
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                current_app.logger.debug("unexpected embedding failure", exc_info=True)
+                payload = _warming_payload(
+                    "Unable to embed query.",
+                    code="embedding_failure",
+                    extra={"error": str(exc), "model": embed_model_name},
+                )
+                payload["llm_used"] = llm_enabled
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
+            try:
+                results = store.query(
+                    vector=query_vector,
+                    k=engine_config.retrieval.k,
+                    similarity_threshold=engine_config.retrieval.similarity_threshold,
+                )
+            except Exception as exc:
+                current_app.logger.debug("vector store query failed", exc_info=True)
+                payload = _warming_payload(
+                    "Vector store warming up.",
+                    code="vector_store_unavailable",
+                    extra={"error": str(exc)},
+                )
+                payload["llm_used"] = llm_enabled
+                payload["results"] = []
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
+            if len(results) < engine_config.retrieval.min_hits:
+                try:
+                    coldstart.build_index(query, use_llm=llm_enabled, llm_model=llm_model)
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    current_app.logger.debug("coldstart build failed", exc_info=True)
+                    payload = _warming_payload(
+                        "Focused crawl warming up.",
+                        code="coldstart_unavailable",
+                        extra={"error": str(exc)},
+                    )
+                    payload["llm_used"] = llm_enabled
+                    payload["results"] = [_serialize_chunk(chunk) for chunk in results]
+                    if llm_model:
+                        payload["llm_model"] = llm_model
+                    return jsonify(payload)
+                try:
+                    query_vector = embedder.embed_query(query)
+                except EmbeddingError as exc:
+                    message = (
+                        "Unable to generate embeddings from Ollama. "
+                        f"Ensure the model '{embed_model_name}' is installed and running."
+                    )
+                    payload = _embedding_unavailable_payload(
+                        f"{message} ({exc})", status=embed_status
+                    )
+                    payload["llm_used"] = llm_enabled
+                    if llm_model:
+                        payload["llm_model"] = llm_model
+                    return jsonify(payload)
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    current_app.logger.debug("unexpected embedding failure after coldstart", exc_info=True)
+                    payload = _warming_payload(
+                        "Unable to embed query after coldstart.",
+                        code="embedding_failure",
+                        extra={"error": str(exc), "model": embed_model_name},
+                    )
+                    payload["llm_used"] = llm_enabled
+                    if llm_model:
+                        payload["llm_model"] = llm_model
+                    return jsonify(payload)
+                try:
+                    results = store.query(
+                        vector=query_vector,
+                        k=engine_config.retrieval.k,
+                        similarity_threshold=engine_config.retrieval.similarity_threshold,
+                    )
+                except Exception as exc:
+                    current_app.logger.debug("vector store query failed after coldstart", exc_info=True)
+                    payload = _warming_payload(
+                        "Vector store warming up.",
+                        code="vector_store_unavailable",
+                        extra={"error": str(exc)},
+                    )
+                    payload["llm_used"] = llm_enabled
+                    payload["results"] = []
+                    if llm_model:
+                        payload["llm_model"] = llm_model
+                    return jsonify(payload)
+
+            serialized_results = [_serialize_chunk(chunk) for chunk in results]
+
+            if not results:
+                payload = {
+                    "status": "no_results",
+                    "answer": "I could not find relevant information in the local index.",
+                    "sources": [],
+                    "k": 0,
+                    "results": serialized_results,
+                    "llm_used": llm_enabled,
+                }
+                payload["hits"] = serialized_results
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
+            if not llm_enabled:
+                payload = {
+                    "status": "ok_no_llm",
+                    "answer": "",
+                    "sources": [],
+                    "k": len(serialized_results),
+                    "results": serialized_results,
+                    "llm_used": False,
+                }
+                payload["hits"] = serialized_results
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
+            try:
+                rag_result: RagResult = rag_agent.run(query, results)
+            except OllamaClientError as exc:
+                payload = {
+                    "status": "ok",
+                    "code": "rag_error",
+                    "detail": f"Failed to generate answer: {exc}",
+                    "answer": "",
+                    "sources": [],
+                    "k": 0,
+                    "results": serialized_results,
+                    "llm_used": llm_enabled,
+                }
+                payload["hits"] = serialized_results
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                current_app.logger.debug("rag agent failed", exc_info=True)
+                payload = {
+                    "status": "ok",
+                    "code": "rag_error",
+                    "detail": "Answer generation warming up.",
+                    "error": str(exc),
+                    "answer": "",
+                    "sources": [],
+                    "k": 0,
+                    "results": serialized_results,
+                    "llm_used": llm_enabled,
+                }
+                payload["hits"] = serialized_results
+                if llm_model:
+                    payload["llm_model"] = llm_model
+                return jsonify(payload)
+
             payload = {
                 "status": "ok",
-                "results": results,
-                "llm_used": bool(llm_enabled),
+                "answer": rag_result.answer,
+                "sources": rag_result.sources,
+                "k": rag_result.used,
+                "results": serialized_results,
+                "llm_used": llm_enabled,
             }
-            if context:
-                payload["confidence"] = context.get("confidence")
-                if context.get("trigger_reason"):
-                    payload["trigger_reason"] = context.get("trigger_reason")
-                if context.get("seed_count"):
-                    payload["seed_count"] = context.get("seed_count")
-            if job_id:
-                payload["job_id"] = job_id
-                payload["last_index_time"] = search_service.last_index_time()
-                if len(results) < app_config.smart_min_results or context.get("trigger_reason") == "low_confidence":
-                    payload["status"] = "focused_crawl_running"
+            payload["hits"] = serialized_results
             if llm_model:
                 payload["llm_model"] = llm_model
             return jsonify(payload)
-        return jsonify({"error": "Semantic search unavailable"}), 503
-
-    store = cast(VectorStore, store)
-    embedder = cast(OllamaEmbedder, embedder)
-    coldstart = cast(ColdStartIndexer, coldstart)
-    rag_agent = cast(RagAgent, rag_agent)
-
-    embed_model_name = (
-        current_app.config.get("RAG_EMBED_MODEL_NAME") or engine_config.models.embed
-    )
-
-    ready, embed_model_name, embed_status, detail = _ensure_embedder_ready(
-        embed_manager, embedder, embed_model_name
-    )
-    if not ready:
-        payload = _embedding_unavailable_payload(
-            detail or "Embedding model is not ready.", status=embed_status
-        )
-        payload["llm_used"] = llm_enabled
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    try:
-        query_vector = embedder.embed_query(query)
-    except EmbeddingError as exc:
-        message = (
-            "Unable to generate embeddings from Ollama. "
-            f"Ensure the model '{embed_model_name}' is installed and running."
-        )
-        payload = _embedding_unavailable_payload(f"{message} ({exc})", status=embed_status)
-        payload["llm_used"] = llm_enabled
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-    except Exception as exc:  # pragma: no cover - defensive logging
-        current_app.logger.debug("unexpected embedding failure", exc_info=True)
-        payload = _warming_payload(
-            "Unable to embed query.",
-            code="embedding_failure",
-            extra={"error": str(exc), "model": embed_model_name},
-        )
-        payload["llm_used"] = llm_enabled
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    try:
-        results = store.query(
-            vector=query_vector,
-            k=engine_config.retrieval.k,
-            similarity_threshold=engine_config.retrieval.similarity_threshold,
-        )
-    except Exception as exc:
-        current_app.logger.debug("vector store query failed", exc_info=True)
-        payload = _warming_payload(
-            "Vector store warming up.",
-            code="vector_store_unavailable",
-            extra={"error": str(exc)},
-        )
-        payload["llm_used"] = llm_enabled
-        payload["results"] = []
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    if len(results) < engine_config.retrieval.min_hits:
-        try:
-            coldstart.build_index(query, use_llm=llm_enabled, llm_model=llm_model)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            current_app.logger.debug("coldstart build failed", exc_info=True)
-            payload = _warming_payload(
-                "Focused crawl warming up.",
-                code="coldstart_unavailable",
-                extra={"error": str(exc)},
-            )
-            payload["llm_used"] = llm_enabled
-            payload["results"] = [_serialize_chunk(chunk) for chunk in results]
-            if llm_model:
-                payload["llm_model"] = llm_model
-            return jsonify(payload)
-        try:
-            query_vector = embedder.embed_query(query)
-        except EmbeddingError as exc:
-            message = (
-                "Unable to generate embeddings from Ollama. "
-                f"Ensure the model '{embed_model_name}' is installed and running."
-            )
-            payload = _embedding_unavailable_payload(
-                f"{message} ({exc})", status=embed_status
-            )
-            payload["llm_used"] = llm_enabled
-            if llm_model:
-                payload["llm_model"] = llm_model
-            return jsonify(payload)
-        except Exception as exc:  # pragma: no cover - defensive logging
-            current_app.logger.debug("unexpected embedding failure after coldstart", exc_info=True)
-            payload = _warming_payload(
-                "Unable to embed query after coldstart.",
-                code="embedding_failure",
-                extra={"error": str(exc), "model": embed_model_name},
-            )
-            payload["llm_used"] = llm_enabled
-            if llm_model:
-                payload["llm_model"] = llm_model
-            return jsonify(payload)
-        try:
-            results = store.query(
-                vector=query_vector,
-                k=engine_config.retrieval.k,
-                similarity_threshold=engine_config.retrieval.similarity_threshold,
-            )
-        except Exception as exc:
-            current_app.logger.debug("vector store query failed after coldstart", exc_info=True)
-            payload = _warming_payload(
-                "Vector store warming up.",
-                code="vector_store_unavailable",
-                extra={"error": str(exc)},
-            )
-            payload["llm_used"] = llm_enabled
-            payload["results"] = []
-            if llm_model:
-                payload["llm_model"] = llm_model
-            return jsonify(payload)
-
-    serialized_results = [_serialize_chunk(chunk) for chunk in results]
-
-    if not results:
-        payload = {
-            "status": "no_results",
-            "answer": "I could not find relevant information in the local index.",
-            "sources": [],
-            "k": 0,
-            "results": serialized_results,
-            "llm_used": llm_enabled,
-        }
-        payload["hits"] = serialized_results
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    if not llm_enabled:
-        payload = {
-            "status": "ok_no_llm",
-            "answer": "",
-            "sources": [],
-            "k": len(serialized_results),
-            "results": serialized_results,
-            "llm_used": False,
-        }
-        payload["hits"] = serialized_results
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    try:
-        rag_result: RagResult = rag_agent.run(query, results)
-    except OllamaClientError as exc:
-        payload = {
-            "status": "ok",
-            "code": "rag_error",
-            "detail": f"Failed to generate answer: {exc}",
-            "answer": "",
-            "sources": [],
-            "k": 0,
-            "results": serialized_results,
-            "llm_used": llm_enabled,
-        }
-        payload["hits"] = serialized_results
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-    except Exception as exc:  # pragma: no cover - defensive logging
-        current_app.logger.debug("rag agent failed", exc_info=True)
-        payload = {
-            "status": "ok",
-            "code": "rag_error",
-            "detail": "Answer generation warming up.",
-            "error": str(exc),
-            "answer": "",
-            "sources": [],
-            "k": 0,
-            "results": serialized_results,
-            "llm_used": llm_enabled,
-        }
-        payload["hits"] = serialized_results
-        if llm_model:
-            payload["llm_model"] = llm_model
-        return jsonify(payload)
-
-    payload = {
-        "status": "ok",
-        "answer": rag_result.answer,
-        "sources": rag_result.sources,
-        "k": rag_result.used,
-        "results": serialized_results,
-        "llm_used": llm_enabled,
-    }
-    payload["hits"] = serialized_results
-    if llm_model:
-        payload["llm_model"] = llm_model
-    return jsonify(payload)

--- a/engine/llm/ollama_client.py
+++ b/engine/llm/ollama_client.py
@@ -7,6 +7,8 @@ from typing import Any, Iterable, Mapping, Sequence
 
 import requests
 
+from observability import start_span
+
 
 class OllamaClientError(RuntimeError):
     """Raised when the Ollama API returns an unexpected response."""
@@ -64,37 +66,13 @@ class OllamaClient:
         }
         if options:
             payload["options"] = options
-        response = self._session.post(
-            f"{self.base_url}/api/chat",
-            json=payload,
-            timeout=self.timeout,
-        )
-        try:
-            response.raise_for_status()
-        except requests.RequestException as exc:  # pragma: no cover - network failure
-            raise OllamaClientError(str(exc)) from exc
-        try:
-            data = response.json()
-        except ValueError as exc:  # pragma: no cover - unexpected response
-            raise OllamaClientError("Invalid JSON response from Ollama") from exc
-        message = data.get("message") or {}
-        content = message.get("content") or data.get("response")
-        if not isinstance(content, str):
-            raise OllamaClientError("Unexpected chat response payload")
-        content = content.strip()
-        if not content:
-            raise OllamaClientError("Empty chat response payload")
-        return content
-
-    # ------------------------------------------------------------------
-    # Embeddings
-    # ------------------------------------------------------------------
-    def embed(self, model: str, texts: Sequence[str]) -> list[list[float]]:
-        embeddings: list[list[float]] = []
-        for text in texts:
-            payload = {"model": model, "prompt": text}
+        with start_span(
+            "ollama.chat",
+            attributes={"llm.model": model},
+            inputs={"message_count": len(messages)},
+        ) as span:
             response = self._session.post(
-                f"{self.base_url}/api/embeddings",
+                f"{self.base_url}/api/chat",
                 json=payload,
                 timeout=self.timeout,
             )
@@ -106,11 +84,48 @@ class OllamaClient:
                 data = response.json()
             except ValueError as exc:  # pragma: no cover - unexpected response
                 raise OllamaClientError("Invalid JSON response from Ollama") from exc
-            vector = data.get("embedding")
-            if not isinstance(vector, Iterable):
-                raise OllamaClientError("Unexpected embedding response payload")
-            embeddings.append([float(value) for value in vector])
-        return embeddings
+            message = data.get("message") or {}
+            content = message.get("content") or data.get("response")
+            if not isinstance(content, str):
+                raise OllamaClientError("Unexpected chat response payload")
+            content = content.strip()
+            if not content:
+                raise OllamaClientError("Empty chat response payload")
+            if span is not None:
+                span.set_attribute("llm.response_chars", len(content))
+            return content
+
+    # ------------------------------------------------------------------
+    # Embeddings
+    # ------------------------------------------------------------------
+    def embed(self, model: str, texts: Sequence[str]) -> list[list[float]]:
+        embeddings: list[list[float]] = []
+        with start_span(
+            "ollama.embed",
+            attributes={"llm.model": model, "text.count": len(texts)},
+        ) as span:
+            for text in texts:
+                payload = {"model": model, "prompt": text}
+                response = self._session.post(
+                    f"{self.base_url}/api/embeddings",
+                    json=payload,
+                    timeout=self.timeout,
+                )
+                try:
+                    response.raise_for_status()
+                except requests.RequestException as exc:  # pragma: no cover - network failure
+                    raise OllamaClientError(str(exc)) from exc
+                try:
+                    data = response.json()
+                except ValueError as exc:  # pragma: no cover - unexpected response
+                    raise OllamaClientError("Invalid JSON response from Ollama") from exc
+                vector = data.get("embedding")
+                if not isinstance(vector, Iterable):
+                    raise OllamaClientError("Unexpected embedding response payload")
+                embeddings.append([float(value) for value in vector])
+            if span is not None and embeddings:
+                span.set_attribute("embedding.dims", len(embeddings[0]))
+            return embeddings
 
     def embed_one(self, model: str, text: str) -> list[float]:
         [vector] = self.embed(model, [text])
@@ -122,25 +137,28 @@ class OllamaClient:
     def list_models(self) -> list[str]:
         """Return the names of models available on the Ollama instance."""
 
-        try:
-            response = self._session.get(
-                f"{self.base_url}/api/tags", timeout=self.timeout
-            )
-            response.raise_for_status()
-        except requests.RequestException as exc:  # pragma: no cover - network failure
-            raise OllamaClientError(str(exc)) from exc
-        try:
-            payload = response.json()
-        except ValueError as exc:  # pragma: no cover - unexpected response
-            raise OllamaClientError("Invalid JSON response from Ollama") from exc
-        models: list[str] = []
-        for item in payload.get("models", []):
-            if not isinstance(item, dict):
-                continue
-            name = item.get("name")
-            if isinstance(name, str) and name:
-                models.append(name)
-        return models
+        with start_span("ollama.list_models", attributes={"ollama.host": self.base_url}) as span:
+            try:
+                response = self._session.get(
+                    f"{self.base_url}/api/tags", timeout=self.timeout
+                )
+                response.raise_for_status()
+            except requests.RequestException as exc:  # pragma: no cover - network failure
+                raise OllamaClientError(str(exc)) from exc
+            try:
+                payload = response.json()
+            except ValueError as exc:  # pragma: no cover - unexpected response
+                raise OllamaClientError("Invalid JSON response from Ollama") from exc
+            models: list[str] = []
+            for item in payload.get("models", []):
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                if isinstance(name, str) and name:
+                    models.append(name)
+            if span is not None:
+                span.set_attribute("ollama.model_count", len(models))
+            return models
 
     def has_model(self, model: str) -> bool:
         """Return ``True`` when the named model is available locally."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ version = "0.1.0"
 description = "Self-hosted deep research agent"
 authors = [{name = "Akeem"}]
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "langsmith==0.4.31",
+    "opentelemetry-sdk==1.37.0",
+]
 
 [tool.setuptools]
 packages = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ flask-cors==4.0.0
 PyYAML==6.0.2
 python-dotenv==1.0.1
 requests==2.32.3
+langsmith==0.4.31
+opentelemetry-sdk==1.37.0
 chromadb==0.5.3
 duckdb==1.0.0
 scrapy==2.11.2


### PR DESCRIPTION
## Summary
- add LangSmith + OpenTelemetry dependencies and tracing scaffolding in observability helpers
- instrument Flask endpoints, vector/LLM/retrieval layers, and runtime spans for crawl → normalize → index → query
- ensure AgentRuntime remains compatible with legacy LocalVectorStore by adding an adapter that reuses deterministic embeddings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dec23f09948321a520d5514b87cba3