### PR TITLE
Refactor planner orchestration with LangGraph state machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _MAIN_0.toc
 !backend/app/api/index.py
 !backend/app/api/shadow.py
 !backend/app/api/discovery.py
+!backend/app/api/plan.py
 !backend/app/middleware/request_id.py
 !backend/app/middleware/__init__.py
 !backend/app/services/ollama_client.py

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -55,6 +55,7 @@ def create_app() -> Flask:
     from .api import jobs as jobs_api
     from .api import metrics as metrics_api
     from .api import refresh as refresh_api
+    from .api import plan as plan_api
     from .api import shadow as shadow_api
     from .api import research as research_api
     from .api import seeds as seeds_api
@@ -267,6 +268,7 @@ def create_app() -> Flask:
     app.register_blueprint(diagnostics_api.bp)
     app.register_blueprint(metrics_api.bp)
     app.register_blueprint(refresh_api.bp)
+    app.register_blueprint(plan_api.bp)
     app.register_blueprint(agent_tools_api.bp)
     app.register_blueprint(seeds_api.bp)
     app.register_blueprint(extract_api.bp)

--- a/backend/app/api/plan.py
+++ b/backend/app/api/plan.py
@@ -1,0 +1,49 @@
+"""Planner endpoint executing the LangGraph state machine."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping
+
+from flask import Blueprint, Response, current_app, jsonify, request
+
+from observability import start_span
+
+bp = Blueprint("plan_api", __name__, url_prefix="/api")
+
+
+def _normalize_context(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+@bp.post("/plan")
+def execute_plan() -> Response:
+    payload = request.get_json(silent=True) or {}
+    query = payload.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return jsonify({"ok": False, "error": "query is required"}), 400
+    query_text = query.strip()
+    context = _normalize_context(payload.get("context"))
+    model = payload.get("model") if isinstance(payload.get("model"), str) else None
+    planner = current_app.config.get("RAG_PLANNER_AGENT")
+    if planner is None:
+        return jsonify({"ok": False, "error": "planner unavailable"}), 503
+    start = time.perf_counter()
+    with start_span("planner.plan", attributes={"query_length": len(query_text)}):
+        try:
+            result = planner.run(query_text, context=context, model=model)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            current_app.logger.exception("planner execution failed")
+            return jsonify({"ok": False, "error": str(exc)}), 500
+    duration = time.perf_counter() - start
+    response = {
+        "ok": True,
+        "duration": duration,
+        "result": result,
+        "events": result.get("events", []),
+    }
+    if result.get("langsmith_run_id"):
+        response["langsmith_run_id"] = result["langsmith_run_id"]
+    return jsonify(response), 200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ description = "Self-hosted deep research agent"
 authors = [{name = "Akeem"}]
 requires-python = ">=3.11"
 dependencies = [
-    "langsmith==0.4.31",
+    "langsmith==0.1.147",
     "opentelemetry-sdk==1.37.0",
+    "langchain-core==0.2.11",
+    "langgraph==0.0.58",
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@ flask-cors==4.0.0
 PyYAML==6.0.2
 python-dotenv==1.0.1
 requests==2.32.3
-langsmith==0.4.31
+langsmith==0.1.147
 opentelemetry-sdk==1.37.0
+langchain-core==0.2.11
+langgraph==0.0.58
 chromadb==0.5.3
 duckdb==1.0.0
 scrapy==2.11.2

--- a/server/agent.py
+++ b/server/agent.py
@@ -1,16 +1,23 @@
-"""Planner agent orchestrating tool calls to satisfy research queries."""
+"""Planner agent orchestrating tool calls via LangGraph state machine."""
 
 from __future__ import annotations
 
 import json
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+from langgraph.graph import END, StateGraph
+
+from langsmith import Client
 
 from .llm import LLMError, OllamaJSONClient
 from .logging_utils import get_logger
-from .tools import ToolDispatcher
 from .runlog import add_run_log_line
+from .tools import ToolDispatcher
 
 LOGGER = get_logger("agent")
 
@@ -65,6 +72,12 @@ FEW_SHOT_MESSAGES: Sequence[Mapping[str, str]] = (
     },
 )
 
+CRITIQUE_PROMPT = (
+    "You critique answers for the research planner. "
+    "Respond with JSON containing should_retry (bool) and feedback (string). "
+    "Request a retry when the answer is empty, contradicts the query, or lacks sources when evidence was requested."
+)
+
 
 @dataclass
 class PlannerAgent:
@@ -73,8 +86,29 @@ class PlannerAgent:
     default_model: str | None = None
     fallback_model: str | None = None
     max_iterations: int = 6
+    node_timeout: float = 45.0
+    llm_max_attempts: int = 3
+    llm_initial_backoff: float = 1.0
     logger: Logger = field(default=LOGGER)
+    langsmith_project: str | None = None
 
+    def __post_init__(self) -> None:
+        self.langsmith_project = (
+            self.langsmith_project
+            or os.getenv("LANGSMITH_PROJECT")
+            or os.getenv("LANGCHAIN_PROJECT")
+            or "self-hosted-search"
+        )
+        try:
+            self._langsmith_client: Client | None = Client()
+        except Exception:  # pragma: no cover - optional instrumentation
+            self._langsmith_client = None
+            self.logger.debug("planner.langsmith disabled", exc_info=True)
+        self._graph = self._build_graph()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def run(
         self,
         query: str,
@@ -84,78 +118,402 @@ class PlannerAgent:
     ) -> Mapping[str, Any]:
         self.logger.info("planner starting query=%s", query)
         add_run_log_line(f"planner start: {query[:80]}")
-        messages = list(self._bootstrap_messages(query, context))
-        steps: list[dict[str, Any]] = []
-        active_model = model or self.default_model
-        last_model_used: str | None = None
-        for iteration in range(1, self.max_iterations + 1):
-            self.logger.debug("planner iteration=%s", iteration)
-            response, used_model = self._chat_with_fallback(messages, active_model)
-            last_model_used = used_model
-            steps.append(
-                {
-                    "iteration": iteration,
-                    "response": response,
-                    "model": used_model,
-                }
+        initial_state: dict[str, Any] = {
+            "query": query,
+            "context": dict(context or {}),
+            "messages": list(self._bootstrap_messages(query, context)),
+            "steps": [],
+            "loop_count": 0,
+            "graph_events": [],
+            "model_override": model,
+            "start_time": time.perf_counter(),
+        }
+        run_id = self._start_langsmith_run(query, initial_state["context"])
+        try:
+            final_state: MutableMapping[str, Any] = self._graph.invoke(
+                initial_state,
+                config={
+                    "recursion_limit": max(self.max_iterations * 2, 8),
+                    "metadata": {
+                        "query": query,
+                        "max_iterations": self.max_iterations,
+                    },
+                },
             )
-            self.logger.info("planner step %s response=%s", iteration, json.dumps(response))
-            messages.append({"role": "assistant", "content": json.dumps(response)})
-            if used_model and used_model != active_model:
-                active_model = used_model
-            message_type = response.get("type")
-            if message_type == "tool":
-                tool_name = response.get("tool")
-                params = response.get("params") if isinstance(response.get("params"), Mapping) else {}
-                tool_result = self.tools.execute(tool_name, params)
-                steps[-1]["tool"] = tool_result
-                self.logger.info(
-                    "planner tool %s result=%s", tool_name, json.dumps(tool_result)
-                )
-                messages.append(
-                    {
-                        "role": "tool",
-                        "name": str(tool_name),
-                        "content": json.dumps(tool_result),
-                    }
-                )
-                continue
-            if message_type == "final":
-                final_payload = self._normalize_final(response, steps, last_model_used)
-                add_run_log_line("planner finished")
-                self.logger.info("planner completed query=%s", query)
-                return final_payload
-            error = {
-                "ok": False,
-                "tool": "planner",
-                "error": "invalid response type",
-                "received": response,
+        except Exception as exc:
+            if run_id:
+                self._finish_langsmith_run(run_id, error=str(exc))
+            self.logger.exception("planner graph failed")
+            add_run_log_line("planner error")
+            raise
+        final_payload = self._finalize_payload(final_state)
+        if run_id:
+            self._finish_langsmith_run(run_id, outputs=final_payload)
+            final_payload["langsmith_run_id"] = str(run_id)
+        add_run_log_line("planner finished")
+        self.logger.info("planner completed query=%s", query)
+        return final_payload
+
+    # ------------------------------------------------------------------
+    # Graph wiring
+    # ------------------------------------------------------------------
+    def _build_graph(self) -> Any:
+        graph: StateGraph = StateGraph(dict)
+        graph.add_node("plan", self._node_plan)
+        graph.add_node("tool_select", self._node_tool_select)
+        graph.add_node("tool_run", self._node_tool_run)
+        graph.add_node("retrieve_context", self._node_retrieve_context)
+        graph.add_node("respond", self._node_respond)
+        graph.add_node("critique", self._node_critique)
+        graph.add_node("decide_retry", self._node_decide_retry)
+
+        graph.set_entry_point("plan")
+        graph.add_conditional_edges(
+            "plan",
+            self._route_plan,
+            {
+                "tool": "tool_select",
+                "respond": "respond",
+                "retry": "decide_retry",
+            },
+        )
+        graph.add_edge("tool_select", "tool_run")
+        graph.add_edge("tool_run", "retrieve_context")
+        graph.add_edge("retrieve_context", "decide_retry")
+        graph.add_edge("respond", "critique")
+        graph.add_edge("critique", "decide_retry")
+        graph.add_conditional_edges(
+            "decide_retry",
+            self._route_decision,
+            {
+                "continue": "plan",
+                "stop": END,
+            },
+        )
+        return graph.compile()
+
+    # ------------------------------------------------------------------
+    # Node helpers
+    # ------------------------------------------------------------------
+    def _node_plan(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        iteration = state.get("loop_count", 0) + 1
+        state["loop_count"] = iteration
+        start_time = time.perf_counter()
+        try:
+            response, model_used = self._call_llm_json(
+                state.get("messages", []),
+                state.get("model_override") or self.default_model,
+            )
+            if not isinstance(response, Mapping):
+                raise LLMError("Planner LLM returned non-JSON payload")
+            payload = dict(response)
+            state["last_model_used"] = model_used
+            state["current_action"] = payload
+            step = {"iteration": iteration, "response": payload, "model": model_used}
+            state.setdefault("steps", []).append(step)
+            state.setdefault("messages", []).append(
+                {"role": "assistant", "content": json.dumps(payload)}
+            )
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="plan",
+                status="success",
+                duration=duration,
+                model=model_used,
+            )
+        except Exception as exc:  # pragma: no cover - defensive branch
+            duration = time.perf_counter() - start_time
+            state["current_action"] = None
+            state.setdefault("errors", []).append(str(exc))
+            state["pending_error"] = {"node": "plan", "error": str(exc)}
+            self._record_event(
+                state,
+                node="plan",
+                status="error",
+                duration=duration,
+                error=str(exc),
+            )
+        return state
+
+    def _route_plan(self, state: Mapping[str, Any]) -> str:
+        action = state.get("current_action")
+        if not isinstance(action, Mapping):
+            return "retry"
+        message_type = action.get("type")
+        if message_type == "tool":
+            return "tool"
+        if message_type == "final":
+            return "respond"
+        return "retry"
+
+    def _node_tool_select(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        action = state.get("current_action")
+        start_time = time.perf_counter()
+        tool_name = action.get("tool") if isinstance(action, Mapping) else None
+        params = action.get("params") if isinstance(action, Mapping) else None
+        if not isinstance(tool_name, str) or not tool_name:
+            state["pending_error"] = {"node": "tool_select", "error": "missing tool name"}
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="tool_select",
+                status="error",
+                duration=duration,
+                error="missing tool name",
+            )
+            return state
+        if not self.tools.has_tool(tool_name):
+            state["pending_error"] = {
+                "node": "tool_select",
+                "error": f"unknown tool: {tool_name}",
             }
-            steps[-1]["error"] = error
-            self.logger.warning("planner invalid response -> %s", json.dumps(error))
-            messages.append(
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="tool_select",
+                status="error",
+                duration=duration,
+                error=f"unknown tool: {tool_name}",
+            )
+            return state
+        state["selected_tool"] = tool_name
+        state["tool_params"] = dict(params) if isinstance(params, Mapping) else {}
+        duration = time.perf_counter() - start_time
+        self._record_event(
+            state,
+            node="tool_select",
+            status="success",
+            duration=duration,
+            tool=tool_name,
+        )
+        return state
+
+    def _node_tool_run(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        tool = state.get("selected_tool")
+        params = state.get("tool_params") or {}
+        start_time = time.perf_counter()
+        if not isinstance(tool, str):
+            state["pending_error"] = {"node": "tool_run", "error": "no tool selected"}
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="tool_run",
+                status="error",
+                duration=duration,
+                error="no tool selected",
+            )
+            return state
+
+        def _call() -> Mapping[str, Any]:
+            return self.tools.execute(tool, params if isinstance(params, Mapping) else {})
+
+        try:
+            result = self._run_with_timeout(_call, self.node_timeout, f"tool {tool}")
+        except Exception as exc:  # pragma: no cover - network/tool failures
+            duration = time.perf_counter() - start_time
+            state["tool_result"] = {"ok": False, "tool": tool, "error": str(exc)}
+            state["pending_error"] = {"node": "tool_run", "error": str(exc)}
+            self._record_event(
+                state,
+                node="tool_run",
+                status="error",
+                duration=duration,
+                error=str(exc),
+                tool=tool,
+            )
+            return state
+        duration = time.perf_counter() - start_time
+        state["tool_result"] = result
+        steps = state.setdefault("steps", [])
+        if steps:
+            steps[-1]["tool"] = result
+        self._record_event(
+            state,
+            node="tool_run",
+            status="success",
+            duration=duration,
+            tool=tool,
+            ok=bool(result.get("ok")),
+        )
+        return state
+
+    def _node_retrieve_context(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        start_time = time.perf_counter()
+        tool = state.get("selected_tool")
+        result = state.get("tool_result")
+        if isinstance(result, Mapping):
+            state.setdefault("messages", []).append(
                 {
                     "role": "tool",
-                    "name": "planner",
-                    "content": json.dumps(error),
+                    "name": str(tool or "unknown"),
+                    "content": json.dumps(result),
                 }
             )
-        self.logger.warning("planner hit iteration limit for query=%s", query)
-        payload = {
-            "type": "final",
-            "answer": "",
-            "sources": [],
-            "error": "iteration limit reached",
-            "steps": steps,
-        }
-        add_run_log_line("planner hit iteration limit")
-        if last_model_used:
-            payload["planner_model_used"] = last_model_used
-        return payload
+            if not result.get("ok"):
+                state["pending_error"] = {
+                    "node": "tool_run",
+                    "error": str(result.get("error", "tool failed")),
+                }
+        duration = time.perf_counter() - start_time
+        self._record_event(
+            state,
+            node="retrieve_context",
+            status="success",
+            duration=duration,
+            tool=str(tool) if tool else None,
+        )
+        state.pop("selected_tool", None)
+        state.pop("tool_params", None)
+        return state
 
+    def _node_respond(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        start_time = time.perf_counter()
+        action = state.get("current_action")
+        payload = dict(action) if isinstance(action, Mapping) else None
+        if payload is None:
+            state["pending_error"] = {"node": "respond", "error": "missing final payload"}
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="respond",
+                status="error",
+                duration=duration,
+                error="missing final payload",
+            )
+            return state
+        final = self._normalize_final(payload, state.get("steps", []), state.get("last_model_used"))
+        state["final_candidate"] = final
+        duration = time.perf_counter() - start_time
+        self._record_event(
+            state,
+            node="respond",
+            status="success",
+            duration=duration,
+        )
+        return state
+
+    def _node_critique(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        start_time = time.perf_counter()
+        final = state.get("final_candidate")
+        if not isinstance(final, Mapping):
+            state["critique"] = {"should_retry": True, "feedback": "no final candidate"}
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="critique",
+                status="error",
+                duration=duration,
+                error="no final candidate",
+            )
+            return state
+        critique_messages = [
+            {"role": "system", "content": CRITIQUE_PROMPT},
+            {
+                "role": "user",
+                "content": json.dumps(
+                    {
+                        "query": state.get("query"),
+                        "answer": final.get("answer", ""),
+                        "sources": final.get("sources", []),
+                    }
+                ),
+            },
+        ]
+        try:
+            critique, model_used = self._call_llm_json(
+                critique_messages,
+                state.get("model_override") or self.default_model,
+            )
+            feedback = str(critique.get("feedback", "")).strip()
+            should_retry = bool(critique.get("should_retry"))
+            state["critique"] = {
+                "should_retry": should_retry,
+                "feedback": feedback,
+                "model": model_used,
+            }
+            duration = time.perf_counter() - start_time
+            self._record_event(
+                state,
+                node="critique",
+                status="success",
+                duration=duration,
+                model=model_used,
+                should_retry=should_retry,
+            )
+            if should_retry:
+                state["pending_error"] = {
+                    "node": "critique",
+                    "error": feedback or "critique requested retry",
+                }
+        except Exception as exc:  # pragma: no cover - critique best effort
+            duration = time.perf_counter() - start_time
+            state["critique"] = {
+                "should_retry": False,
+                "feedback": f"critique_failed: {exc}",
+            }
+            self._record_event(
+                state,
+                node="critique",
+                status="error",
+                duration=duration,
+                error=str(exc),
+            )
+        return state
+
+    def _node_decide_retry(self, state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        pending_error = state.pop("pending_error", None)
+        critique = state.get("critique") if isinstance(state.get("critique"), Mapping) else {}
+        loop_count = state.get("loop_count", 0)
+        decision: dict[str, Any] = {"action": "continue", "reason": ""}
+        if loop_count >= self.max_iterations:
+            decision = {"action": "stop", "reason": "max_loops"}
+            state["final"] = {
+                "type": "final",
+                "answer": "",
+                "sources": [],
+                "error": "iteration limit reached",
+                "steps": state.get("steps", []),
+            }
+        elif pending_error:
+            decision["reason"] = pending_error.get("error")
+        elif critique and critique.get("should_retry"):
+            decision["reason"] = critique.get("feedback") or "critique retry"
+        elif state.get("final_candidate"):
+            decision = {"action": "stop", "reason": "finalized"}
+            final = dict(state.get("final_candidate") or {})
+            final.setdefault("steps", state.get("steps", []))
+            if state.get("last_model_used"):
+                final.setdefault("planner_model_used", state["last_model_used"])
+            state["final"] = final
+        state["decision"] = decision
+        if decision["action"] == "continue":
+            state.pop("final_candidate", None)
+            state.pop("tool_result", None)
+            state.pop("current_action", None)
+        duration = 0.0
+        self._record_event(
+            state,
+            node="decide_retry",
+            status="success",
+            duration=duration,
+            action=decision.get("action"),
+            reason=decision.get("reason"),
+        )
+        return state
+
+    def _route_decision(self, state: Mapping[str, Any]) -> str:
+        decision = state.get("decision")
+        if isinstance(decision, Mapping) and decision.get("action") == "stop":
+            return "stop"
+        return "continue"
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
     def _bootstrap_messages(
         self, query: str, context: Mapping[str, Any] | None
-    ) -> Iterable[Mapping[str, Any]]:
+    ) -> Sequence[Mapping[str, Any]]:
         yield {"role": "system", "content": SYSTEM_PROMPT}
         yield from FEW_SHOT_MESSAGES
         payload = {
@@ -184,61 +542,154 @@ class PlannerAgent:
             final["planner_model_used"] = model_used
         return final
 
-    def _chat_with_fallback(
+    def _record_event(
+        self,
+        state: MutableMapping[str, Any],
+        *,
+        node: str,
+        status: str,
+        duration: float,
+        **details: Any,
+    ) -> None:
+        event = {
+            "node": node,
+            "status": status,
+            "timestamp": time.time(),
+            "duration": duration,
+            "details": details,
+        }
+        state.setdefault("graph_events", []).append(event)
+        summary = {
+            "node": node,
+            "status": status,
+            "duration": round(duration, 3),
+            **{k: v for k, v in details.items() if v is not None},
+        }
+        self.logger.info("planner.node %s", json.dumps(summary, default=str))
+
+    def _run_with_timeout(
+        self, func: Callable[[], Any], timeout: float, label: str
+    ) -> Any:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(func)
+            try:
+                return future.result(timeout=timeout)
+            except FuturesTimeoutError as exc:  # pragma: no cover - timeout guard
+                future.cancel()
+                raise TimeoutError(f"{label} timed out after {timeout} seconds") from exc
+
+    def _call_llm_json(
         self,
         messages: Sequence[Mapping[str, Any]],
-        model: str | None,
+        model_hint: str | None,
     ) -> tuple[Mapping[str, Any], str | None]:
-        primary_model = model or self.default_model
+        attempts = 0
+        delay = self.llm_initial_backoff
+        last_error: Exception | None = None
+        candidates = self._model_candidates(model_hint)
+        while attempts < self.llm_max_attempts:
+            attempts += 1
+            for candidate in candidates:
+                model_name = candidate or getattr(self.llm, "default_model", None)
+                try:
+                    response = self._run_with_timeout(
+                        lambda: self.llm.chat_json(messages, model=candidate),
+                        self.node_timeout,
+                        f"llm ({model_name or '<auto>'})",
+                    )
+                    if not isinstance(response, Mapping):
+                        raise LLMError("LLM returned non-JSON payload")
+                    payload = dict(response)
+                    used_model = candidate or getattr(self.llm, "default_model", None)
+                    if used_model:
+                        payload.setdefault("planner_model_used", used_model)
+                    return payload, used_model
+                except Exception as exc:
+                    last_error = exc
+                    self.logger.warning(
+                        "planner.llm failure attempt=%s model=%s error=%s",
+                        attempts,
+                        model_name or "<auto>",
+                        exc,
+                    )
+                    time.sleep(min(delay, 5.0))
+            delay = min(delay * 2, 10.0)
+        raise LLMError(str(last_error) if last_error else "LLM unavailable")
 
-        def _call(use_model: str | None) -> tuple[Mapping[str, Any], str | None]:
-            response = self.llm.chat_json(messages, model=use_model)
-            if not isinstance(response, Mapping):
-                raise LLMError("Planner LLM returned non-JSON payload")
-            payload = dict(response)
-            resolved = use_model or getattr(self.llm, "default_model", None)
-            if resolved:
-                payload.setdefault("planner_model_used", resolved)
-            return payload, resolved
+    def _model_candidates(self, preferred: str | None) -> tuple[str | None, ...]:
+        primary = preferred or self.default_model
+        if not self.fallback_model or self.fallback_model == primary:
+            return (primary,)
+        return (primary, self.fallback_model)
 
+    def _start_langsmith_run(
+        self, query: str, context: Mapping[str, Any]
+    ) -> str | None:
+        client = self._langsmith_client
+        if client is None:
+            return None
         try:
-            self.logger.info(
-                "planner.llm attempt=primary model=%s", primary_model or "<auto>"
+            run = client.create_run(
+                name="planner.graph",
+                inputs={
+                    "query": query,
+                    "context": self._jsonable(context),
+                },
+                run_type="chain",
+                project_name=self.langsmith_project,
+                metadata={"max_iterations": self.max_iterations},
             )
-            return _call(primary_model)
-        except LLMError as err:
-            self.logger.warning(
-                "planner.primary_failed model=%s err=%s",
-                primary_model or "<auto>",
-                err,
+            return run.get("id") if isinstance(run, Mapping) else None
+        except Exception:  # pragma: no cover - observability optional
+            self.logger.debug("planner.langsmith create_run failed", exc_info=True)
+            return None
+
+    def _finish_langsmith_run(
+        self,
+        run_id: str,
+        *,
+        outputs: Mapping[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        client = self._langsmith_client
+        if client is None:
+            return
+        try:
+            client.update_run(
+                run_id=run_id,
+                outputs=self._jsonable(outputs) if outputs is not None else None,
+                error=error,
             )
-            if (
-                not self.fallback_model
-                or self.fallback_model == primary_model
-                or not self._is_model_missing(err)
-            ):
-                raise
-            try:
-                self.logger.info(
-                    "planner.llm attempt=fallback model=%s", self.fallback_model
-                )
-                return _call(self.fallback_model)
-            except Exception as fallback_err:
-                self.logger.error(
-                    "planner.fallback_failed model=%s err=%s",
-                    self.fallback_model,
-                    fallback_err,
-                )
-                raise
+        except Exception:  # pragma: no cover - observability optional
+            self.logger.debug("planner.langsmith update_run failed", exc_info=True)
 
     @staticmethod
-    def _is_model_missing(error: Exception) -> bool:
-        text = str(error).lower()
-        return (
-            ("404" in text and "not found" in text)
-            or "model not found" in text
-            or "no such model" in text
-        )
+    def _jsonable(value: Any) -> Any:
+        if value is None:
+            return None
+        try:
+            json.dumps(value)
+            return value
+        except TypeError:
+            return json.loads(json.dumps(value, default=str))
+
+    def _finalize_payload(self, state: Mapping[str, Any]) -> Mapping[str, Any]:
+        final = state.get("final")
+        if isinstance(final, Mapping):
+            payload = dict(final)
+        else:
+            payload = {
+                "type": "final",
+                "answer": "",
+                "sources": [],
+                "error": "planner did not complete",
+                "steps": state.get("steps", []),
+            }
+        events = state.get("graph_events", [])
+        payload["events"] = list(events)
+        if state.get("last_model_used"):
+            payload.setdefault("planner_model_used", state.get("last_model_used"))
+        return payload
 
 
 __all__ = ["PlannerAgent", "SYSTEM_PROMPT", "FEW_SHOT_MESSAGES"]

--- a/server/tools.py
+++ b/server/tools.py
@@ -287,6 +287,12 @@ class ToolDispatcher:
             return {"ok": False, "tool": tool, "error": str(exc)}
         return {"ok": True, "tool": tool, "result": result}
 
+    def has_tool(self, name: str) -> bool:
+        return name in self._registry
+
+    def list_tools(self) -> Sequence[str]:
+        return tuple(sorted(self._registry.keys()))
+
 
 __all__ = [
     "ToolExecutionError",


### PR DESCRIPTION
## Summary
- replace the planner loop with a LangGraph-driven state machine that adds node-level metrics, retries, and LangSmith tracing
- expose a new `/api/plan` endpoint that returns planner graph events for debugging
- pin langchain-core/langgraph dependencies and extend the tool dispatcher with discovery helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'observability')*

------
https://chatgpt.com/codex/tasks/task_e_68deca65090883218f6c6f4114f32871