### PR TITLE
Guard make dev against backend port conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,31 @@ dev:
 	  $(MAKE) first-run; \
 	fi
 	@# Detached with nohup so dev survives terminal exits; logs in logs/*.log
-	@echo "▶ Starting API (Flask)…"
-	@if ! lsof -iTCP:$(BACKEND_PORT) -sTCP:LISTEN >/dev/null 2>&1; then \
-	  mkdir -p logs; \
-	  (BACKEND_PORT=$(BACKEND_PORT) nohup $(VENV_PY) -m backend.app > logs/backend.log 2>&1 & echo $$! > logs/backend.pid) ; \
-	fi
+    @echo "▶ Starting API (Flask)…"
+    @PORT_PIDS="$$(lsof -tiTCP:$(BACKEND_PORT) -sTCP:LISTEN 2>/dev/null || true)"; \
+    CONFLICT=0; \
+    for pid in $$PORT_PIDS; do \
+      CMD="$$(ps -p "$$pid" -o command= 2>/dev/null | tr -d '\r' || true)"; \
+      if [ -z "$$CMD" ]; then \
+        continue; \
+      fi; \
+      case "$$CMD" in \
+        *"python -m backend.app"*) ;; \
+        *) \
+          echo "❌ Port $(BACKEND_PORT) is in use by: $$CMD"; \
+          echo "   Please rerun with BACKEND_PORT=5051 make dev"; \
+          CONFLICT=1; \
+          break; \
+          ;; \
+      esac; \
+    done; \
+    if [ $$CONFLICT -eq 1 ]; then \
+      exit 1; \
+    fi; \
+    if [ -z "$$PORT_PIDS" ]; then \
+      mkdir -p logs; \
+      (BACKEND_PORT=$(BACKEND_PORT) nohup $(VENV_PY) -m backend.app > logs/backend.log 2>&1 & echo $$! > logs/backend.pid) ; \
+    fi
 	@echo "⏳ Waiting for API…"
 	@bash -c 'for i in $$(seq 1 60); do curl -fsS "$(API_URL)" >/dev/null && exit 0; sleep 0.5; done; echo "API not ready" >&2; exit 1'
 	@echo "▶ Starting Frontend (Next.js)…"

--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ Open the browser at `http://localhost:3100` to use the UI. Make sure `ollama`
 is listening on `http://127.0.0.1:11434` (or adjust `OLLAMA_HOST`). If
 `localhost:5050` is busy (macOS ships AirPlay on that port), run
 `BACKEND_PORT=5051 make dev` instead; the proxy will automatically follow the
-updated port. The Flask API root now returns a JSON ping to confirm the service
-is API-only and that the UI lives entirely in Next.js.
+updated port. `make dev` now detects conflicting listeners and exits early with
+a message naming the offender along with the override hint above. The Flask API
+root now returns a JSON ping to confirm the service is API-only and that the UI
+lives entirely in Next.js.
 
 Verify the stack after startup with:
 


### PR DESCRIPTION
## Summary
- add a guard to `make dev` that inspects any listener on the backend port and exits if it is not the project backend
- keep existing startup flow when the port is free or already owned by our backend
- update the README troubleshooting note to explain the new conflict message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df24022fd48321917fe1ea84d594f8