### PR TITLE
Add optional browser auto-open flag for dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,23 @@ dev:
 	  ) ; \
 	fi
 	@echo "✅ UI http://127.0.0.1:$(FRONTEND_PORT)  |  API http://127.0.0.1:$(BACKEND_PORT)"
+	@if [ "$(AUTO_OPEN_BROWSER)" = "1" ]; then \
+	  URL="http://127.0.0.1:$(FRONTEND_PORT)"; \
+	  OS=$$(uname -s); \
+	  case "$$OS" in \
+	    Darwin) \
+	      (open "$$URL" >/dev/null 2>&1 &) || true; \
+	      ;; \
+	    Linux) \
+	      if command -v xdg-open >/dev/null 2>&1; then \
+	        (xdg-open "$$URL" >/dev/null 2>&1 &) || true; \
+	      fi; \
+	      ;; \
+	    MINGW*|MSYS*|CYGWIN*) \
+	      (cmd /c start "" "$$URL" >/dev/null 2>&1 &) || true; \
+	      ;; \
+	  esac; \
+	fi
 
 stop:
 	@echo "🛑 Stopping dev processes…"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ make dev
   your browser at `http://localhost:3100`; all `/api/*` calls proxy to the
   Flask API at the URL derived from `NEXT_PUBLIC_API_BASE_URL` (defaults to
   `http://127.0.0.1:${BACKEND_PORT}` with a fallback of `5050`).
+  Opt in with `AUTO_OPEN_BROWSER=1 make dev` to launch that URL automatically
+  once the frontend listener is ready (macOS uses `open`, Linux uses
+  `xdg-open`, and Windows shells delegate to `cmd /c start`; failures are
+  ignored so headless environments stay quiet).
 - Streams frontend dev instrumentation (via `/api/dev/log`) into the backend
   terminal so you can observe chat/search actions alongside Flask logs.
 - Tears both processes down when either exits or you press


### PR DESCRIPTION
## Summary
- add an AUTO_OPEN_BROWSER=1 opt-in that opens the dev UI once the frontend starts
- document how to enable the flag alongside the existing `make dev` instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df26a33cc8832188df5518a87ea3ca