### PR TITLE
Add shadow mode toggle and refresh UX enhancements

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -252,8 +252,20 @@ def create_app() -> Flask:
         AGENT_RUNTIME=agent_runtime,
         VECTOR_INDEX_SERVICE=vector_index_service,
     )
-    shadow_manager = ShadowIndexer(app=app, runner=runner, vector_index=vector_index_service)
+    feature_shadow_mode = os.getenv("FEATURE_SHADOW_MODE", "0").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    shadow_manager = ShadowIndexer(
+        app=app,
+        runner=runner,
+        vector_index=vector_index_service,
+        enabled=feature_shadow_mode,
+    )
     app.config.setdefault("SHADOW_INDEX_MANAGER", shadow_manager)
+    app.config.setdefault("FEATURE_SHADOW_MODE", feature_shadow_mode)
     app.config.setdefault(
         "SEED_REGISTRY_PATH",
         Path(__file__).resolve().parents[2] / "seeds" / "registry.yaml",

--- a/backend/app/api/shadow.py
+++ b/backend/app/api/shadow.py
@@ -8,10 +8,53 @@ bp = Blueprint("shadow_api", __name__, url_prefix="/api/shadow")
 
 
 def _get_manager():
-    manager = current_app.config.get("SHADOW_INDEX_MANAGER")
+    return current_app.config.get("SHADOW_INDEX_MANAGER")
+
+
+def _manager_or_unavailable():
+    manager = _get_manager()
     if manager is None:
-        raise RuntimeError("Shadow index manager not configured")
-    return manager
+        return None, (jsonify({"error": "shadow_unavailable"}), 503)
+    return manager, None
+
+
+def _coerce_enabled(value) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "on", "yes"}:
+            return True
+        if normalized in {"0", "false", "off", "no"}:
+            return False
+    return None
+
+
+@bp.get("")
+def shadow_config():
+    manager, error_response = _manager_or_unavailable()
+    if error_response is not None:
+        return error_response
+
+    config = manager.get_config()
+    return jsonify(config), 200
+
+
+@bp.post("")
+def update_shadow_config():
+    manager, error_response = _manager_or_unavailable()
+    if error_response is not None:
+        return error_response
+
+    payload = request.get_json(silent=True) or {}
+    enabled_value = _coerce_enabled(payload.get("enabled"))
+    if enabled_value is None:
+        return jsonify({"error": "invalid_enabled"}), 400
+
+    config = manager.set_enabled(enabled_value)
+    return jsonify(config), 200
 
 
 @bp.post("/queue")
@@ -21,11 +64,17 @@ def queue_shadow():
     if not url:
         return jsonify({"error": "url_required"}), 400
 
-    manager = _get_manager()
+    manager, error_response = _manager_or_unavailable()
+    if error_response is not None:
+        return error_response
     try:
         state = manager.enqueue(url)
     except ValueError:
         return jsonify({"error": "url_required"}), 400
+    except RuntimeError as exc:
+        if str(exc) == "shadow_disabled":
+            return jsonify({"error": "shadow_disabled"}), 409
+        raise
     return jsonify(state), 202
 
 
@@ -34,7 +83,9 @@ def shadow_status():
     url = (request.args.get("url") or "").strip()
     if not url:
         return jsonify({"error": "url_required"}), 400
-    manager = _get_manager()
+    manager, error_response = _manager_or_unavailable()
+    if error_response is not None:
+        return error_response
     state = manager.status(url)
     return jsonify(state), 200
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -28,10 +28,9 @@ const baseConfig = {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  allowedDevOrigins: [
-    "http://localhost:3100",
-    "http://127.0.0.1:3100",
-  ],
+  experimental: {
+    allowedDevOrigins: ["http://127.0.0.1:3100", "http://localhost:3100"],
+  },
   ...baseConfig,
 };
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2791,6 +2791,18 @@
         }
       }
     },
+    "node_modules/@vitejs/plugin-react-swc/node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",

--- a/frontend/src/components/web-preview.tsx
+++ b/frontend/src/components/web-preview.tsx
@@ -195,7 +195,13 @@ export function WebPreview({
                 variant="outline"
                 size="icon"
                 aria-label="Open in new tab"
-                onClick={() => onOpenInNewTab?.(url)}
+                onClick={() => {
+                  if (onOpenInNewTab) {
+                    onOpenInNewTab(url);
+                  } else if (typeof window !== "undefined") {
+                    window.open(url, "_blank", "noopener,noreferrer");
+                  }
+                }}
               >
                 <ExternalLink className="h-4 w-4" />
               </Button>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -198,6 +198,16 @@ export interface ShadowStatus {
   updated_at?: number;
 }
 
+export interface ShadowConfig {
+  enabled: boolean;
+  queued?: number;
+  running?: number;
+  lastUrl?: string | null;
+  lastState?: string | null;
+  updatedAt?: number | null;
+  lastUpdatedAt?: number | null;
+}
+
 export interface DiscoveryPreview {
   id: string;
   path: string;


### PR DESCRIPTION
## Summary
- add backend shadow mode configuration endpoints and persist the toggle state
- refresh the workspace UI with a shadow mode switch, improved crawl flow wiring, and updated in-app browser behavior
- harden client refresh handling, surface new APIs in tests, and allow dev iframe origins in Next.js

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68df5ea489cc8321a438ff613752351f