### PR TITLE
feat: queue pending vectors and expose server time metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,10 +37,12 @@ _MAIN_0.toc
 !backend/app/api/shipit_diag.py
 !backend/app/api/shipit_history.py
 !backend/app/api/shipit_ingest.py
+!backend/app/api/meta.py
 !backend/app/middleware/request_id.py
 !backend/app/middleware/__init__.py
 !backend/app/services/ollama_client.py
 !backend/app/services/vector_index.py
+!backend/app/services/pending_vector_worker.py
 !backend/app/services/agent_browser.py
 !backend/app/services/local_discovery.py
 !backend/app/services/progress_bus.py
@@ -62,9 +64,11 @@ _MAIN_0.toc
 !tests/api/test_progress_api.py
 !tests/api/test_visits_api.py
 !tests/api/test_docs_api.py
+!tests/api/test_meta_api.py
 !tests/e2e/test_agent_browser.py
 !tests/backend/test_local_discovery.py
 !tests/backend/test_vector_index_filters.py
+!tests/backend/test_vector_index_retry.py
 !tests/backend/test_agent_runtime.py
 /.venv
 .venv/

--- a/backend/app/api/meta.py
+++ b/backend/app/api/meta.py
@@ -1,0 +1,27 @@
+"""Meta endpoints exposing server clocks and runtime metadata."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify
+
+bp = Blueprint("meta_api", __name__, url_prefix="/api/meta")
+
+
+@bp.get("/time")
+def server_time():
+    now_utc = datetime.now(timezone.utc)
+    local_now = datetime.now().astimezone()
+    tz_name = local_now.tzname() or time.tzname[0]
+    payload = {
+        "server_time": local_now.isoformat(timespec="seconds"),
+        "server_time_utc": now_utc.isoformat(timespec="seconds"),
+        "server_timezone": tz_name,
+        "epoch_ms": int(time.time() * 1000),
+    }
+    return jsonify(payload), 200
+
+
+__all__ = ["bp"]

--- a/backend/app/api/shadow.py
+++ b/backend/app/api/shadow.py
@@ -57,6 +57,15 @@ def update_shadow_config():
     return jsonify(config), 200
 
 
+@bp.post("/toggle")
+def toggle_shadow():
+    manager, error_response = _manager_or_unavailable()
+    if error_response is not None:
+        return error_response
+    config = manager.toggle()
+    return jsonify(config), 200
+
+
 @bp.post("/queue")
 def queue_shadow():
     payload = request.get_json(silent=True) or {}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -58,6 +58,7 @@ class AppConfig:
     agent_plans_dir: Path
     agent_sessions_dir: Path
     telemetry_dir: Path
+    shadow_state_path: Path
     agent_max_fetch_per_turn: int
     agent_coverage_threshold: float
     focused_enabled: bool
@@ -100,6 +101,10 @@ class AppConfig:
             os.getenv("LAST_INDEX_TIME_PATH"), data_dir / "state" / ".last_index_time"
         )
         _guard_directory(last_index_time_path.parent, label="LAST_INDEX_TIME_PATH parent")
+        shadow_state_path = _resolve_path(
+            os.getenv("SHADOW_STATE_PATH"), data_dir / "state" / "shadow_state.json"
+        )
+        _guard_directory(shadow_state_path.parent, label="SHADOW_STATE_PATH parent")
         logs_dir = _guard_directory(
             _resolve_path(os.getenv("LOGS_DIR"), data_dir / "logs"), label="LOGS_DIR"
         )
@@ -166,6 +171,7 @@ class AppConfig:
             agent_plans_dir=agent_plans_dir,
             agent_sessions_dir=agent_sessions_dir,
             telemetry_dir=telemetry_dir,
+            shadow_state_path=shadow_state_path,
             agent_max_fetch_per_turn=agent_max_fetch_per_turn,
             agent_coverage_threshold=agent_coverage_threshold,
             focused_enabled=focused_enabled,
@@ -196,6 +202,7 @@ class AppConfig:
             self.ledger_path.parent,
             self.simhash_path.parent,
             self.last_index_time_path.parent,
+            self.shadow_state_path.parent,
             self.learned_web_db_path.parent,
             self.app_state_db_path.parent,
             self.frontier_db_path.parent,

--- a/backend/app/db/migrations/002_pending_vectors.sql
+++ b/backend/app/db/migrations/002_pending_vectors.sql
@@ -1,0 +1,39 @@
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS pending_documents (
+  doc_id TEXT PRIMARY KEY,
+  job_id TEXT,
+  url TEXT,
+  title TEXT,
+  resolved_title TEXT,
+  doc_hash TEXT,
+  sim_signature INTEGER,
+  metadata TEXT,
+  created_at REAL DEFAULT (strftime('%s','now')),
+  updated_at REAL DEFAULT (strftime('%s','now'))
+);
+
+CREATE TABLE IF NOT EXISTS pending_chunks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  doc_id TEXT NOT NULL UNIQUE,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  metadata TEXT,
+  created_at REAL DEFAULT (strftime('%s','now')),
+  updated_at REAL DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(doc_id) REFERENCES pending_documents(doc_id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_chunks_doc_seq ON pending_chunks(doc_id, chunk_index);
+
+CREATE TABLE IF NOT EXISTS pending_vectors_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  doc_id TEXT NOT NULL,
+  attempts INTEGER DEFAULT 0,
+  next_attempt_at REAL DEFAULT (strftime('%s','now')),
+  created_at REAL DEFAULT (strftime('%s','now')),
+  updated_at REAL DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(doc_id) REFERENCES pending_documents(doc_id) ON DELETE CASCADE,
+  UNIQUE(doc_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pending_vectors_ready ON pending_vectors_queue(next_attempt_at ASC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_vectors_doc ON pending_vectors_queue(doc_id);

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -20,9 +20,11 @@ def connect(db_path: Path | str) -> sqlite3.Connection:
 
 
 def migrate(connection: sqlite3.Connection) -> None:
-    """Apply bootstrap migration(s) to *connection*."""
+    """Apply all SQL migrations located in :mod:`backend.app.db.migrations`."""
 
-    migration_path = MIGRATIONS_DIR / "001_init.sql"
-    sql = migration_path.read_text(encoding="utf-8")
-    with connection:
-        connection.executescript(sql)
+    for migration_path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        sql = migration_path.read_text(encoding="utf-8")
+        if not sql.strip():
+            continue
+        with connection:
+            connection.executescript(sql)

--- a/backend/app/services/pending_vector_worker.py
+++ b/backend/app/services/pending_vector_worker.py
@@ -1,0 +1,111 @@
+"""Background worker draining pending vectorization tasks."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Mapping, Sequence
+
+from backend.app.db import AppStateDB
+from backend.app.services.vector_index import EmbedderUnavailableError, VectorIndexService
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PendingVectorWorker:
+    """Polls :class:`AppStateDB` for pending documents and embeds them."""
+
+    def __init__(
+        self,
+        state_db: AppStateDB,
+        vector_index: VectorIndexService,
+        *,
+        interval: float = 5.0,
+        batch_size: int = 5,
+        max_backoff: float = 300.0,
+    ) -> None:
+        self._state_db = state_db
+        self._vector_index = vector_index
+        self._interval = max(1.0, float(interval))
+        self._batch_size = max(1, int(batch_size))
+        self._max_backoff = max(30.0, float(max_backoff))
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="pending-vector-worker", daemon=True)
+
+    def start(self) -> None:
+        if self._thread.is_alive():
+            return
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                batch = self._state_db.pop_pending_documents(self._batch_size)
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception("failed to pop pending vector documents")
+                time.sleep(self._interval)
+                continue
+
+            if not batch:
+                self._stop.wait(self._interval)
+                continue
+
+            for record in batch:
+                doc_id = str(record.get("doc_id"))
+                attempts = int(record.get("attempts") or 0)
+                chunks = record.get("chunks") or []
+                if not chunks:
+                    LOGGER.debug("removing empty pending document %s", doc_id)
+                    self._state_db.clear_pending_document(doc_id)
+                    continue
+                try:
+                    self._vector_index.index_from_pending(
+                        doc_id=doc_id,
+                        title=str(record.get("title") or ""),
+                        resolved_title=str(record.get("resolved_title") or record.get("title") or ""),
+                        doc_hash=str(record.get("doc_hash") or ""),
+                        sim_signature=record.get("sim_signature"),
+                        url=str(record.get("url") or ""),
+                        metadata=self._ensure_mapping(record.get("metadata")),
+                        chunks=[
+                            (int(chunk.get("index", idx)), str(chunk.get("text", "")), self._ensure_mapping(chunk.get("metadata")))
+                            for idx, chunk in enumerate(chunks)
+                        ],
+                    )
+                except EmbedderUnavailableError as exc:
+                    backoff = min(self._max_backoff, self._interval * (2 ** attempts))
+                    LOGGER.info(
+                        "embedder unavailable; rescheduling pending doc %s in %.1fs (%s)",
+                        doc_id,
+                        backoff,
+                        exc,
+                    )
+                    self._state_db.reschedule_pending_document(
+                        doc_id,
+                        delay=backoff,
+                        attempts=attempts + 1,
+                    )
+                except Exception:  # pragma: no cover - defensive logging
+                    LOGGER.exception("failed to index pending document %s", doc_id)
+                    self._state_db.reschedule_pending_document(
+                        doc_id,
+                        delay=min(self._max_backoff, self._interval * (2 ** (attempts + 1))),
+                        attempts=attempts + 1,
+                    )
+                else:
+                    self._state_db.clear_pending_document(doc_id)
+
+    @staticmethod
+    def _ensure_mapping(value: Any) -> Mapping[str, Any]:
+        if isinstance(value, Mapping):
+            return value
+        return {}
+
+
+__all__ = ["PendingVectorWorker"]

--- a/frontend/src/components/copilot-header.tsx
+++ b/frontend/src/components/copilot-header.tsx
@@ -20,6 +20,12 @@ interface CopilotHeaderProps {
   installMessage?: string | null;
   reachable?: boolean;
   statusLabel?: string;
+  timeSummary?: {
+    serverLocal: string;
+    serverUtc: string;
+    serverZone: string;
+    clientZone: string;
+  } | null;
 }
 
 export function CopilotHeader({
@@ -31,6 +37,7 @@ export function CopilotHeader({
   installMessage,
   reachable = true,
   statusLabel,
+  timeSummary,
 }: CopilotHeaderProps) {
   const hasModels = chatModels.length > 0;
   const disabled = installing || chatModels.length === 0;
@@ -43,6 +50,14 @@ export function CopilotHeader({
           <p className="text-xs text-muted-foreground">
             {statusLabel ?? (installing ? "Installing model" : hasModels ? "Ready" : "No models detected")}
           </p>
+          {timeSummary ? (
+            <p
+              className="text-xs text-muted-foreground/80"
+              title={`Server UTC ${timeSummary.serverUtc}`}
+            >
+              Server: {timeSummary.serverLocal} ({timeSummary.serverZone}) • You: {timeSummary.clientZone}
+            </p>
+          ) : null}
         </div>
         {hasModels ? (
           <div className="flex items-center gap-2 text-xs">

--- a/frontend/src/components/job-status.tsx
+++ b/frontend/src/components/job-status.tsx
@@ -55,19 +55,30 @@ export function JobStatus({ jobs }: JobStatusProps) {
           const meta = STATUS_META[job.state];
           return (
             <div key={job.jobId} className="rounded border px-3 py-2">
-              <div className="flex items-start justify-between">
-                <div>
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
                   <p className="text-sm font-medium">{job.description ?? job.jobId}</p>
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground mt-1">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <span className={cn("flex items-center gap-1", meta.tone)}>
                       {meta.icon}
                       {meta.label}
                     </span>
-                    {typeof job.etaSeconds === "number" && job.state === "running" && (
-                      <Badge variant="outline">eta {Math.max(job.etaSeconds, 1)}s</Badge>
+                    <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
+                      {job.phase}
+                    </Badge>
+                    {typeof job.etaSeconds === "number" && job.state === "running" && job.etaSeconds > 0 && (
+                      <Badge variant="outline">eta {formatEta(job.etaSeconds)}</Badge>
                     )}
                     <span>Updated {new Date(job.lastUpdated).toLocaleTimeString()}</span>
                   </div>
+                  <div className="flex flex-wrap gap-3 text-[11px] text-muted-foreground">
+                    {renderStat("Fetched", job.stats.pagesFetched)}
+                    {renderStat("Docs", job.stats.docsIndexed)}
+                    {renderStat("Normalized", job.stats.normalizedDocs)}
+                    {renderStat("Embedded", job.stats.embedded)}
+                    {renderStat("Skipped", job.stats.skipped)}
+                  </div>
+                  {job.message && <p className="text-xs text-muted-foreground">{job.message}</p>}
                 </div>
                 {job.error && (
                   <Badge variant="destructive" className="text-[11px]">
@@ -82,4 +93,23 @@ export function JobStatus({ jobs }: JobStatusProps) {
       </CardContent>
     </Card>
   );
+}
+
+function renderStat(label: string, value: number) {
+  return (
+    <span>
+      <span className="font-medium text-foreground">{value}</span> {label}
+    </span>
+  );
+}
+
+function formatEta(seconds: number): string {
+  if (!Number.isFinite(seconds)) return "--";
+  const clamped = Math.max(0, Math.round(seconds));
+  if (clamped < 60) {
+    return `${clamped}s`;
+  }
+  const mins = Math.floor(clamped / 60);
+  const secs = clamped % 60;
+  return `${mins}m ${secs.toString().padStart(2, "0")}s`;
 }

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -75,6 +75,10 @@ describe("sendChat", () => {
       const payload = JSON.parse(body);
       expect(payload.model).toBe("gpt-oss");
       expect(payload.url).toBe("https://example.com");
+      expect(payload.client_timezone).toBe("America/Los_Angeles");
+      expect(payload.server_time).toBe("2024-01-01T12:00:00");
+      expect(payload.server_timezone).toBe("UTC-5");
+      expect(payload.server_time_utc).toBe("2024-01-01T17:00:00Z");
       return response;
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -82,6 +86,10 @@ describe("sendChat", () => {
     const result = await sendChat(history, "hi", {
       model: "gpt-oss",
       url: "https://example.com",
+      clientTimezone: "America/Los_Angeles",
+      serverTime: "2024-01-01T12:00:00",
+      serverTimezone: "UTC-5",
+      serverUtc: "2024-01-01T17:00:00Z",
     });
 
     expect(result.traceId).toBe("req_test");

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -49,12 +49,24 @@ export interface AgentLogEntry {
   meta?: Record<string, unknown>;
 }
 
+export interface JobStatusStats {
+  pagesFetched: number;
+  normalizedDocs: number;
+  docsIndexed: number;
+  skipped: number;
+  deduped: number;
+  embedded: number;
+}
+
 export interface JobStatusSummary {
   jobId: string;
   state: "idle" | "queued" | "running" | "done" | "error";
+  phase: string;
   progress: number;
   etaSeconds?: number;
+  stats: JobStatusStats;
   error?: string;
+  message?: string;
   description?: string;
   lastUpdated: string;
 }

--- a/tests/api/test_meta_api.py
+++ b/tests/api/test_meta_api.py
@@ -1,0 +1,14 @@
+from backend.app import create_app
+
+
+def test_meta_time_endpoint():
+    app = create_app()
+    client = app.test_client()
+
+    response = client.get("/api/meta/time")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["server_time"]
+    assert payload["server_time_utc"]
+    assert payload["server_timezone"]
+    assert isinstance(payload["epoch_ms"], int)

--- a/tests/backend/test_vector_index_retry.py
+++ b/tests/backend/test_vector_index_retry.py
@@ -1,0 +1,95 @@
+import time
+
+import pytest
+
+from backend.app.config import AppConfig
+from backend.app.db import AppStateDB
+from backend.app.services.vector_index import EmbedderUnavailableError, VectorIndexService
+from engine.config import (
+    CrawlConfig,
+    EngineConfig,
+    IndexConfig,
+    ModelConfig,
+    OllamaConfig,
+    RetrievalConfig,
+)
+
+
+def _build_engine_config(tmp_path):
+    persist_dir = tmp_path / "chroma"
+    db_path = tmp_path / "index.duckdb"
+    persist_dir.mkdir(parents=True, exist_ok=True)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return EngineConfig(
+        models=ModelConfig(llm_primary="gpt-oss", llm_fallback=None, embed="embeddinggemma"),
+        ollama=OllamaConfig(base_url="http://127.0.0.1:11434"),
+        retrieval=RetrievalConfig(k=5, min_hits=1, similarity_threshold=0.0),
+        index=IndexConfig(persist_dir=persist_dir, db_path=db_path),
+        crawl=CrawlConfig(
+            user_agent="test",
+            request_timeout=1,
+            read_timeout=1,
+            max_pages=1,
+            sleep_seconds=0.0,
+        ),
+    )
+
+
+@pytest.fixture()
+def vector_service(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    chroma_dir = tmp_path / "chroma_store"
+    duckdb_path = tmp_path / "index.duckdb"
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("CHROMA_PERSIST_DIR", str(chroma_dir))
+    monkeypatch.setenv("CHROMA_DB_PATH", str(duckdb_path))
+    monkeypatch.setenv("FOCUSED_CRAWL_ENABLED", "0")
+    monkeypatch.setenv("EMBED_TEST_MODE", "0")
+
+    app_config = AppConfig.from_env()
+    app_config.ensure_dirs()
+    state_db = AppStateDB(app_config.app_state_db_path)
+
+    engine_config = _build_engine_config(tmp_path)
+    service = VectorIndexService(engine_config=engine_config, app_config=app_config, state_db=state_db)
+    return service, state_db
+
+
+def test_embed_with_retry_attempts(monkeypatch, vector_service):
+    service, _ = vector_service
+    attempts: list[int] = []
+
+    def fake_embed(texts):
+        attempts.append(len(texts))
+        raise EmbedderUnavailableError(service._embed_model, detail="warming")
+
+    monkeypatch.setattr(service, "_embed_documents", fake_embed)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(EmbedderUnavailableError):
+        service._embed_with_retry(["hello"], attempts=3, initial_delay=0.0)
+
+    assert len(attempts) == 3
+
+
+def test_upsert_document_queues_pending(vector_service, monkeypatch):
+    service, state_db = vector_service
+
+    def fake_embed(texts):
+        raise EmbedderUnavailableError(service._embed_model, detail="warming")
+
+    monkeypatch.setattr(service, "_embed_documents", fake_embed)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    result = service.upsert_document(text="Example document body", url="https://example.com", title="Example")
+    assert result.chunks == 0
+
+    now = time.time()
+    monkeypatch.setattr(time, "time", lambda: now + 10)
+    pending = state_db.pop_pending_documents()
+    assert pending, "expected pending vector records"
+    record = pending[0]
+    assert record["doc_id"]
+    assert record["chunks"]
+    assert record["sim_signature"] is not None


### PR DESCRIPTION
## Summary
- add a `/api/meta/time` endpoint and pass server/client time metadata through chat and UI surfaces
- persist pending vector work during embedder warmup, drain it with a background worker, and remember shadow toggle state
- extend job status serialization for focused crawls so the frontend can display phase, stats, ETA, and progress

## Testing
- pytest tests/api/test_meta_api.py tests/api/test_shadow_api.py tests/backend/test_vector_index_retry.py

------
https://chatgpt.com/codex/tasks/task_e_68e30c82386c83218751f52a486b8327