### PR TITLE
Handle chat link routing between preview and external navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2847,6 +2847,18 @@
         }
       }
     },
+    "node_modules/@vitejs/plugin-react-swc/node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",

--- a/frontend/src/components/__tests__/chat-links.test.tsx
+++ b/frontend/src/components/__tests__/chat-links.test.tsx
@@ -1,0 +1,83 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ChatPanel } from "@/components/chat-panel";
+import { resolveChatLinkNavigation } from "@/components/app-shell";
+import type { ChatMessage } from "@/lib/types";
+
+describe("Chat link handling", () => {
+  beforeAll(() => {
+    if (typeof window !== "undefined" && !window.ResizeObserver) {
+      class ResizeObserver {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+
+      Object.defineProperty(window, "ResizeObserver", {
+        value: ResizeObserver,
+        configurable: true,
+      });
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        value: ResizeObserver,
+        configurable: true,
+      });
+    }
+
+    if (typeof window !== "undefined" && !Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => {};
+    }
+  });
+
+  const baseMessage: ChatMessage = {
+    id: "msg-1",
+    role: "assistant",
+    content: "",
+    createdAt: "",
+    answer: "See the [preview](https://example.com/docs).",
+    citations: ["https://example.com/source", "notes.txt"],
+  };
+
+  it("forwards markdown and citation link clicks to the provided handler", () => {
+    const onLinkClick = vi.fn();
+    render(
+      <ChatPanel
+        messages={[baseMessage]}
+        input=""
+        onInputChange={() => {}}
+        onSend={() => {}}
+        isBusy={false}
+        onApproveAction={() => {}}
+        onEditAction={() => {}}
+        onDismissAction={() => {}}
+        disableInput
+        onLinkClick={onLinkClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "preview" }));
+    fireEvent.click(screen.getByRole("link", { name: "example.com" }));
+
+    expect(onLinkClick).toHaveBeenCalledTimes(2);
+    expect(onLinkClick).toHaveBeenNthCalledWith(1, "https://example.com/docs", expect.any(Object));
+    expect(onLinkClick).toHaveBeenNthCalledWith(2, "https://example.com/source", expect.any(Object));
+  });
+
+  describe("resolveChatLinkNavigation", () => {
+    it("routes same-domain links through the preview navigator", () => {
+      const decision = resolveChatLinkNavigation(
+        "https://example.com/page",
+        "https://example.com/docs",
+      );
+      expect(decision).toEqual({ action: "navigate", url: "https://example.com/docs" });
+    });
+
+    it("opens external domains in a new tab", () => {
+      const decision = resolveChatLinkNavigation(
+        "https://example.com/page",
+        "https://external.test/path",
+      );
+      expect(decision).toEqual({ action: "external", url: "https://external.test/path" });
+    });
+  });
+});

--- a/frontend/src/components/chat-panel.tsx
+++ b/frontend/src/components/chat-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, type ReactNode, type MouseEvent } from "react";
 import { ChevronDown, Loader2, StopCircle } from "lucide-react";
 
 import { ActionCard } from "@/components/action-card";
@@ -25,6 +25,7 @@ interface ChatPanelProps {
   onDismissAction: (action: ProposedAction) => void;
   header?: ReactNode;
   disableInput?: boolean;
+  onLinkClick?: (url: string, event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
 function formatTimestamp(value: string) {
@@ -57,6 +58,7 @@ export function ChatPanel({
   onDismissAction,
   header,
   disableInput = false,
+  onLinkClick,
 }: ChatPanelProps) {
   const formRef = useRef<HTMLFormElement | null>(null);
   const endRef = useRef<HTMLDivElement | null>(null);
@@ -123,7 +125,10 @@ export function ChatPanel({
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                               Answer
                             </p>
-                            <ChatMessageMarkdown text={displayAnswer} />
+                            <ChatMessageMarkdown
+                              text={displayAnswer}
+                              onLinkClick={onLinkClick}
+                            />
                           </section>
                           {message.citations && message.citations.length > 0 ? (
                             <div className="space-y-1 text-xs text-muted-foreground">
@@ -136,9 +141,16 @@ export function ChatPanel({
                                       {citation.startsWith("http") ? (
                                         <a
                                           href={citation}
-                                          target="_blank"
-                                          rel="noreferrer"
+                                          target={onLinkClick ? undefined : "_blank"}
+                                          rel={onLinkClick ? undefined : "noreferrer"}
                                           className="text-foreground/80 hover:underline"
+                                          onClick={(event) => {
+                                            if (!onLinkClick) {
+                                              return;
+                                            }
+                                            event.preventDefault();
+                                            onLinkClick(citation, event);
+                                          }}
                                         >
                                           {label}
                                         </a>
@@ -160,12 +172,16 @@ export function ChatPanel({
                               <ChatMessageMarkdown
                                 text={reasoningText}
                                 className="mt-2 text-xs text-foreground/90"
+                                onLinkClick={onLinkClick}
                               />
                             </details>
                           ) : null}
                         </div>
                       ) : (
-                        <ChatMessageMarkdown text={message.content ?? ""} />
+                        <ChatMessageMarkdown
+                          text={message.content ?? ""}
+                          onLinkClick={onLinkClick}
+                        />
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- thread optional link click callbacks through chat messages and citations so AppShell can intercept navigation
- add preview-aware chat link handler in AppShell that reuses existing navigation or external opener logic based on host matching
- cover chat link delegation and navigation decisions with vitest component and unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e315171c0c8321ba52ec782a59c7eb