### PR TITLE
Improve shadow crawl reliability and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,27 @@ The default behaviour stays fully local: no external APIs are contacted unless
 Ollama is enabled. Set `SMART_USE_LLM=true` in `.env` if you want the toggle
 pre-enabled for every user.
 
+## Shadow mode & embedding queue
+
+- **Default OFF.** The browser shadow crawler now ships disabled on first boot
+  and the UI exposes an explicit toggle. The selection persists in the
+  `app_settings` table so restarts keep your preference.
+- **Progress tracking.** Every background job surfaces a structured payload via
+  `GET /api/jobs/<id>/status` (and `/progress`). Phases advance through
+  `fetching → extracted → embedding → warming_up/indexed` with step counts,
+  retry counters, and ETA estimates. The Next.js header mirrors this with a
+  progress bar and status badge.
+- **Warm-up awareness.** When the embedding model is still loading, documents
+  are stored immediately and appear under the “Pending embeds” card until the
+  background worker drains them. The UI highlights `Embedding model warming up`
+  instead of failing jobs.
+- **Heavier pages.** Playwright navigation now retries with
+  `wait_until="domcontentloaded"` and a 120s timeout when the initial
+  `networkidle` pass times out, improving reliability on script-heavy domains.
+- **Troubleshooting.** The backend keeps a small history of pending chunks with
+  retry counts and last errors (`GET /api/docs/pending`). Use it alongside the
+  job progress view when diagnosing cold starts or slow embeds.
+
 ### Planner LLM fallback
 
 - `models.llm_primary` in `config.yaml` selects the planner's primary Ollama

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -342,8 +342,8 @@ def create_app() -> Flask:
         app=app,
         runner=runner,
         vector_index=vector_index_service,
+        state_db=state_db,
         enabled=feature_shadow_mode,
-        state_path=config.shadow_state_path,
     )
     app.config.setdefault("SHADOW_INDEX_MANAGER", shadow_manager)
     app.config.setdefault("FEATURE_SHADOW_MODE", feature_shadow_mode)

--- a/backend/app/api/docs.py
+++ b/backend/app/api/docs.py
@@ -44,4 +44,11 @@ def document_detail(doc_id: str):
     return jsonify({"item": doc})
 
 
-__all__ = ["bp", "list_docs", "document_detail"]
+@bp.get("/docs/pending")
+def pending_docs():
+    state_db: AppStateDB = current_app.config["APP_STATE_DB"]
+    items = state_db.list_pending_documents(limit=200)
+    return jsonify({"items": items})
+
+
+__all__ = ["bp", "list_docs", "document_detail", "pending_docs"]

--- a/backend/app/db/migrations/003_job_status_settings.sql
+++ b/backend/app/db/migrations/003_job_status_settings.sql
@@ -1,0 +1,59 @@
+BEGIN TRANSACTION;
+
+-- Persist application settings (shadow toggle, etc.).
+CREATE TABLE IF NOT EXISTS app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at REAL DEFAULT (strftime('%s','now'))
+);
+
+INSERT OR IGNORE INTO app_settings(key, value)
+VALUES ('shadow_enabled', 'false');
+
+-- Structured job status/progress tracking for background tasks.
+CREATE TABLE IF NOT EXISTS job_status (
+  job_id TEXT PRIMARY KEY,
+  url TEXT,
+  phase TEXT,
+  steps_total INTEGER DEFAULT 0,
+  steps_completed INTEGER DEFAULT 0,
+  retries INTEGER DEFAULT 0,
+  eta_seconds REAL,
+  message TEXT,
+  started_at REAL DEFAULT (strftime('%s','now')),
+  updated_at REAL DEFAULT (strftime('%s','now'))
+);
+
+-- Extend pending_documents with retry/error metadata for observability.
+ALTER TABLE pending_documents ADD COLUMN last_error TEXT;
+ALTER TABLE pending_documents ADD COLUMN retry_count INTEGER DEFAULT 0;
+
+-- Rebuild pending_chunks to drop the erroneous UNIQUE(doc_id) constraint
+-- while keeping existing data.
+CREATE TABLE IF NOT EXISTS pending_chunks_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  doc_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  metadata TEXT,
+  created_at REAL DEFAULT (strftime('%s','now')),
+  updated_at REAL DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(doc_id) REFERENCES pending_documents(doc_id) ON DELETE CASCADE
+);
+
+INSERT INTO pending_chunks_new(id, doc_id, chunk_index, text, metadata, created_at, updated_at)
+SELECT id, doc_id, chunk_index, text, metadata, created_at, updated_at FROM pending_chunks;
+
+DROP TABLE pending_chunks;
+ALTER TABLE pending_chunks_new RENAME TO pending_chunks;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_chunks_doc_seq ON pending_chunks(doc_id, chunk_index);
+CREATE INDEX IF NOT EXISTS idx_pending_chunks_doc_id ON pending_chunks(doc_id);
+
+-- Backfill retry_count from queue attempts where available.
+UPDATE pending_documents
+   SET retry_count = COALESCE((
+     SELECT attempts FROM pending_vectors_queue WHERE pending_vectors_queue.doc_id = pending_documents.doc_id
+   ), retry_count, 0);
+
+COMMIT;

--- a/backend/app/services/pending_vector_worker.py
+++ b/backend/app/services/pending_vector_worker.py
@@ -64,7 +64,25 @@ class PendingVectorWorker:
                     LOGGER.debug("removing empty pending document %s", doc_id)
                     self._state_db.clear_pending_document(doc_id)
                     continue
+                job_id = str(record.get("job_id") or "") or None
+                status_snapshot = (
+                    self._state_db.get_job_status(job_id) if job_id else None
+                )
+                total_steps = int((status_snapshot or {}).get("steps_total") or 5)
+                started_at = (status_snapshot or {}).get("started_at")
                 try:
+                    if job_id:
+                        self._state_db.upsert_job_status(
+                            job_id,
+                            url=str(record.get("url") or ""),
+                            phase="embedding",
+                            steps_total=total_steps,
+                            steps_completed=max(0, total_steps - 1),
+                            retries=attempts,
+                            eta_seconds=None,
+                            message="Embedding pending document",
+                            started_at=started_at,
+                        )
                     self._vector_index.index_from_pending(
                         doc_id=doc_id,
                         title=str(record.get("title") or ""),
@@ -90,16 +108,54 @@ class PendingVectorWorker:
                         doc_id,
                         delay=backoff,
                         attempts=attempts + 1,
+                        last_error=str(exc),
                     )
+                    if job_id:
+                        self._state_db.upsert_job_status(
+                            job_id,
+                            url=str(record.get("url") or ""),
+                            phase="warming_up",
+                            steps_total=total_steps,
+                            steps_completed=max(0, total_steps - 1),
+                            retries=attempts + 1,
+                            eta_seconds=backoff,
+                            message="Embedding model still warming",
+                            started_at=started_at,
+                        )
                 except Exception:  # pragma: no cover - defensive logging
                     LOGGER.exception("failed to index pending document %s", doc_id)
                     self._state_db.reschedule_pending_document(
                         doc_id,
                         delay=min(self._max_backoff, self._interval * (2 ** (attempts + 1))),
                         attempts=attempts + 1,
+                        last_error="exception",
                     )
+                    if job_id:
+                        self._state_db.upsert_job_status(
+                            job_id,
+                            url=str(record.get("url") or ""),
+                            phase="retrying",
+                            steps_total=total_steps,
+                            steps_completed=max(0, total_steps - 1),
+                            retries=attempts + 1,
+                            eta_seconds=None,
+                            message="Retrying pending document",
+                            started_at=started_at,
+                        )
                 else:
                     self._state_db.clear_pending_document(doc_id)
+                    if job_id:
+                        self._state_db.upsert_job_status(
+                            job_id,
+                            url=str(record.get("url") or ""),
+                            phase="indexed",
+                            steps_total=total_steps,
+                            steps_completed=total_steps,
+                            retries=attempts,
+                            eta_seconds=0.0,
+                            message="Embedding complete",
+                            started_at=started_at,
+                        )
 
     @staticmethod
     def _ensure_mapping(value: Any) -> Mapping[str, Any]:

--- a/frontend/src/components/job-status.tsx
+++ b/frontend/src/components/job-status.tsx
@@ -53,11 +53,15 @@ export function JobStatus({ jobs }: JobStatusProps) {
         )}
         {jobs.map((job) => {
           const meta = STATUS_META[job.state];
+          const percent = Math.max(0, Math.min(100, Math.round(job.progress)));
           return (
             <div key={job.jobId} className="rounded border px-3 py-2">
               <div className="flex items-start justify-between gap-3">
                 <div className="space-y-1">
                   <p className="text-sm font-medium">{job.description ?? job.jobId}</p>
+                  {job.url && (
+                    <p className="text-xs text-muted-foreground truncate">{job.url}</p>
+                  )}
                   <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <span className={cn("flex items-center gap-1", meta.tone)}>
                       {meta.icon}
@@ -68,6 +72,10 @@ export function JobStatus({ jobs }: JobStatusProps) {
                     </Badge>
                     {typeof job.etaSeconds === "number" && job.state === "running" && job.etaSeconds > 0 && (
                       <Badge variant="outline">eta {formatEta(job.etaSeconds)}</Badge>
+                    )}
+                    <Badge variant="outline">{percent}%</Badge>
+                    {typeof job.retries === "number" && job.retries > 0 && (
+                      <Badge variant="outline">retries {job.retries}</Badge>
                     )}
                     <span>Updated {new Date(job.lastUpdated).toLocaleTimeString()}</span>
                   </div>
@@ -86,7 +94,7 @@ export function JobStatus({ jobs }: JobStatusProps) {
                   </Badge>
                 )}
               </div>
-              <Progress value={job.progress} className="mt-2" />
+              <Progress value={percent} className="mt-2" />
             </div>
           );
         })}

--- a/frontend/src/components/pending-embeds-card.tsx
+++ b/frontend/src/components/pending-embeds-card.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Clock } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PendingDocument } from "@/lib/types";
+
+interface PendingEmbedsCardProps {
+  docs: PendingDocument[];
+}
+
+function formatTimestamp(value?: number | null): string {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "--";
+  }
+  const date = new Date(value * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return "--";
+  }
+  return date.toLocaleTimeString();
+}
+
+export function PendingEmbedsCard({ docs }: PendingEmbedsCardProps) {
+  return (
+    <Card className="h-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm">Pending embeds</CardTitle>
+          <span className="text-xs text-muted-foreground">{docs.length}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {docs.length === 0 ? (
+          <p className="text-xs text-muted-foreground">All documents embedded.</p>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {docs.map((doc) => {
+              const label = doc.title && doc.title.trim().length > 0 ? doc.title.trim() : doc.url ?? doc.docId;
+              return (
+                <li key={doc.docId} className="rounded border px-3 py-2">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span className="truncate font-medium text-foreground">{label}</span>
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3.5 w-3.5" aria-hidden />
+                      {formatTimestamp(doc.updatedAt)}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                    <span>Retries {doc.retryCount}</span>
+                    {doc.lastError && <span className="text-destructive">{doc.lastError}</span>}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/shadow-progress.tsx
+++ b/frontend/src/components/shadow-progress.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import type { JobStatusSummary } from "@/lib/types";
+
+interface ShadowProgressProps {
+  job: JobStatusSummary;
+}
+
+function formatEta(seconds?: number) {
+  if (!seconds || !Number.isFinite(seconds)) return "--";
+  const clamped = Math.max(0, Math.round(seconds));
+  if (clamped < 60) return `${clamped}s`;
+  const minutes = Math.floor(clamped / 60);
+  const remaining = clamped % 60;
+  return `${minutes}m ${remaining.toString().padStart(2, "0")}s`;
+}
+
+export function ShadowProgress({ job }: ShadowProgressProps) {
+  const percent = Math.max(0, Math.min(100, Math.round(job.progress)));
+  return (
+    <div className="bg-muted/40 px-3 py-2 text-xs">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-foreground">{job.phase}</span>
+          <Badge variant="outline">{percent}%</Badge>
+          {typeof job.etaSeconds === "number" && job.etaSeconds > 0 && (
+            <Badge variant="outline">eta {formatEta(job.etaSeconds)}</Badge>
+          )}
+          {typeof job.retries === "number" && job.retries > 0 && (
+            <Badge variant="outline">retries {job.retries}</Badge>
+          )}
+        </div>
+        <span className="text-muted-foreground">{new Date(job.lastUpdated).toLocaleTimeString()}</span>
+      </div>
+      <Progress value={percent} className="mt-2" />
+      {job.message && (
+        <p className="mt-2 text-[11px] text-muted-foreground">{job.message}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -69,6 +69,10 @@ export interface JobStatusSummary {
   message?: string;
   description?: string;
   lastUpdated: string;
+  stepsTotal?: number;
+  stepsCompleted?: number;
+  retries?: number;
+  url?: string;
 }
 
 export interface CrawlQueueItem {
@@ -209,6 +213,9 @@ export interface ShadowStatus {
   error_kind?: string | null;
   updatedAt?: number;
   updated_at?: number;
+  phase?: string | null;
+  statusMessage?: string | null;
+  pendingEmbedding?: boolean;
 }
 
 export interface ShadowConfig {
@@ -234,4 +241,13 @@ export interface DiscoveryPreview {
 
 export interface DiscoveryItem extends DiscoveryPreview {
   text: string;
+}
+
+export interface PendingDocument {
+  docId: string;
+  url?: string | null;
+  title?: string | null;
+  retryCount: number;
+  lastError?: string | null;
+  updatedAt?: number | null;
 }

--- a/tests/backend/test_vector_index_retry.py
+++ b/tests/backend/test_vector_index_retry.py
@@ -65,6 +65,7 @@ def test_embed_with_retry_attempts(monkeypatch, vector_service):
         raise EmbedderUnavailableError(service._embed_model, detail="warming")
 
     monkeypatch.setattr(service, "_embed_documents", fake_embed)
+    monkeypatch.setattr(service, "_ensure_embedder_ready", lambda **_kwargs: None)
     monkeypatch.setattr(time, "sleep", lambda _: None)
 
     with pytest.raises(EmbedderUnavailableError):
@@ -80,6 +81,7 @@ def test_upsert_document_queues_pending(vector_service, monkeypatch):
         raise EmbedderUnavailableError(service._embed_model, detail="warming")
 
     monkeypatch.setattr(service, "_embed_documents", fake_embed)
+    monkeypatch.setattr(service, "_ensure_embedder_ready", lambda **_kwargs: None)
     monkeypatch.setattr(time, "sleep", lambda _: None)
 
     result = service.upsert_document(text="Example document body", url="https://example.com", title="Example")


### PR DESCRIPTION
## Summary
- add persistent job status and app settings tables with migration
- harden embedder warmup handling, pending queue upsert logic, and shadow manager retries
- surface shadow job progress and pending embeds in the Next.js UI with new components

## Testing
- pytest tests/backend -q
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e320ff631c8321a6a401947c0dbe03