### PR TITLE
Fix SQLite overflow handling and diagnostics

### DIFF
--- a/backend/app/db/migrations/004_pending_vectors_text.sql
+++ b/backend/app/db/migrations/004_pending_vectors_text.sql
@@ -1,0 +1,126 @@
+BEGIN TRANSACTION;
+
+-- Rebuild pending_documents to ensure large identifiers are stored as TEXT
+-- and timestamps are stored as INTEGER seconds.
+ALTER TABLE pending_documents RENAME TO pending_documents_old;
+
+CREATE TABLE pending_documents (
+  doc_id TEXT PRIMARY KEY,
+  job_id TEXT,
+  url TEXT,
+  title TEXT,
+  resolved_title TEXT,
+  doc_hash TEXT,
+  sim_signature TEXT,
+  metadata TEXT,
+  last_error TEXT,
+  retry_count INTEGER DEFAULT 0,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now'))
+);
+
+INSERT INTO pending_documents(
+  doc_id,
+  job_id,
+  url,
+  title,
+  resolved_title,
+  doc_hash,
+  sim_signature,
+  metadata,
+  last_error,
+  retry_count,
+  created_at,
+  updated_at
+)
+SELECT
+  doc_id,
+  CAST(job_id AS TEXT),
+  url,
+  title,
+  resolved_title,
+  CAST(doc_hash AS TEXT),
+  CASE WHEN sim_signature IS NOT NULL THEN CAST(sim_signature AS TEXT) ELSE NULL END,
+  metadata,
+  last_error,
+  COALESCE(retry_count, 0),
+  COALESCE(CAST(created_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER)),
+  COALESCE(CAST(updated_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER))
+FROM pending_documents_old;
+
+DROP TABLE pending_documents_old;
+
+-- Rebuild pending_chunks with INTEGER timestamps to match pending_documents.
+CREATE TABLE pending_chunks_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  doc_id TEXT NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  metadata TEXT,
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(doc_id) REFERENCES pending_documents(doc_id) ON DELETE CASCADE
+);
+
+INSERT INTO pending_chunks_new(
+  id,
+  doc_id,
+  chunk_index,
+  text,
+  metadata,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  doc_id,
+  chunk_index,
+  text,
+  metadata,
+  COALESCE(CAST(created_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER)),
+  COALESCE(CAST(updated_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER))
+FROM pending_chunks;
+
+DROP TABLE pending_chunks;
+ALTER TABLE pending_chunks_new RENAME TO pending_chunks;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_chunks_doc_seq ON pending_chunks(doc_id, chunk_index);
+CREATE INDEX IF NOT EXISTS idx_pending_chunks_doc_id ON pending_chunks(doc_id);
+
+-- Rebuild pending_vectors_queue with INTEGER timestamps.
+ALTER TABLE pending_vectors_queue RENAME TO pending_vectors_queue_old;
+
+CREATE TABLE pending_vectors_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  doc_id TEXT NOT NULL,
+  attempts INTEGER DEFAULT 0,
+  next_attempt_at INTEGER DEFAULT (strftime('%s','now')),
+  created_at INTEGER DEFAULT (strftime('%s','now')),
+  updated_at INTEGER DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(doc_id) REFERENCES pending_documents(doc_id) ON DELETE CASCADE,
+  UNIQUE(doc_id)
+);
+
+INSERT INTO pending_vectors_queue(
+  id,
+  doc_id,
+  attempts,
+  next_attempt_at,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  doc_id,
+  attempts,
+  COALESCE(CAST(next_attempt_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER)),
+  COALESCE(CAST(created_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER)),
+  COALESCE(CAST(updated_at AS INTEGER), CAST(strftime('%s','now') AS INTEGER))
+FROM pending_vectors_queue_old;
+
+DROP TABLE pending_vectors_queue_old;
+
+CREATE INDEX IF NOT EXISTS idx_pending_vectors_ready ON pending_vectors_queue(next_attempt_at ASC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_vectors_doc ON pending_vectors_queue(doc_id);
+
+COMMIT;

--- a/backend/app/services/local_discovery.py
+++ b/backend/app/services/local_discovery.py
@@ -263,8 +263,13 @@ class LocalDiscoveryService:
 
         with self._lock:
             confirmation = self._confirmations.get(path_str)
-            if confirmation and float(confirmation.get("mtime", 0)) >= mtime:
-                return False
+            if confirmation:
+                action = str(confirmation.get("action", "included")).strip().lower()
+                if action != "retry":
+                    self._seen_mtimes[path_str] = mtime
+                    return False
+                if float(confirmation.get("mtime", 0)) >= mtime:
+                    return False
             seen = self._seen_mtimes.get(path_str)
             if seen and seen >= mtime:
                 return False

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "self-hosted-search-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  }
+}

--- a/e2e/shadow_crawl.spec.ts
+++ b/e2e/shadow_crawl.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 2_000;
+
+test.describe('shadow crawl integration', () => {
+  test('indexes fixture content and makes it searchable', async ({ request }) => {
+    test.skip(process.env.CI === 'true', 'Shadow crawl e2e disabled on CI runners');
+
+    const baseUrl = process.env.APP_BASE_URL ?? 'http://127.0.0.1:8000';
+    const fixtureUrl = process.env.SHADOW_FIXTURE_URL;
+    const fixturePhrase = process.env.SHADOW_FIXTURE_PHRASE;
+
+    test.skip(!fixtureUrl || !fixturePhrase, 'Shadow crawl fixture not configured');
+
+    const queueResponse = await request.post(`${baseUrl}/api/shadow/queue`, {
+      data: { url: fixtureUrl },
+    });
+    expect(queueResponse.status(), 'queue request should succeed').toBeGreaterThanOrEqual(200);
+    expect(queueResponse.status(), 'queue request should succeed').toBeLessThan(400);
+
+    await expect
+      .poll(
+        async () => {
+          const statusResponse = await request.get(`${baseUrl}/api/shadow/status`, {
+            params: { url: fixtureUrl },
+          });
+          if (!statusResponse.ok()) {
+            return 'pending';
+          }
+          const payload = await statusResponse.json();
+          return payload?.phase ?? payload?.status ?? 'pending';
+        },
+        {
+          timeout: DEFAULT_TIMEOUT_MS,
+          message: 'Shadow crawl did not reach indexed state in time',
+          interval: POLL_INTERVAL_MS,
+        },
+      )
+      .toEqual('indexed');
+
+    const searchResponse = await request.post(`${baseUrl}/api/search`, {
+      data: { query: fixturePhrase, limit: 5 },
+    });
+    expect(searchResponse.ok(), 'search request should succeed').toBeTruthy();
+    const searchPayload = await searchResponse.json();
+    const hits = Array.isArray(searchPayload?.results) ? searchPayload.results : [];
+    const matched = hits.some((hit: any) => {
+      const text = `${hit?.title ?? ''} ${hit?.snippet ?? ''}`.toLowerCase();
+      return text.includes(String(fixturePhrase).toLowerCase());
+    });
+    expect(matched, 'search results should include the fixture phrase').toBeTruthy();
+  });
+});

--- a/scripts/check_migrations.sh
+++ b/scripts/check_migrations.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+export DATA_DIR="$TMPDIR/data"
+mkdir -p "$DATA_DIR"
+
+python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from backend.app import create_app
+
+# Ensure the data directory exists before initialising the app configuration.
+Path(os.environ["DATA_DIR"]).mkdir(parents=True, exist_ok=True)
+
+app = create_app()
+app.testing = True
+with app.test_client() as client:
+    response = client.get("/api/diag/db")
+    payload = response.get_json()
+    if response.status_code != 200 or not payload.get("ok"):
+        raise SystemExit(
+            f"schema diagnostics failed: {json.dumps(payload, indent=2, sort_keys=True)}"
+        )
+print("schema diagnostics ok")
+PY

--- a/tests/backend/test_pending_vectors_overflow.py
+++ b/tests/backend/test_pending_vectors_overflow.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.app.db.store import AppStateDB
+
+
+@pytest.fixture()
+def temp_state_db(tmp_path: Path) -> AppStateDB:
+    db_path = tmp_path / "app_state.sqlite3"
+    return AppStateDB(db_path)
+
+
+def test_enqueue_handles_large_identifiers(temp_state_db: AppStateDB) -> None:
+    store = temp_state_db
+    big_job_id = str(2**130)
+    doc_hash = hashlib.sha256(b"overflow-check").hexdigest()
+    sim_signature = 2**63 + 12345
+    doc_id = f"doc-{hashlib.sha1(b'unique').hexdigest()}"
+
+    store.enqueue_pending_document(
+        doc_id=doc_id,
+        job_id=big_job_id,
+        url="https://example.com/article",
+        title="Article",
+        resolved_title="Resolved Title",
+        doc_hash=doc_hash,
+        sim_signature=sim_signature,
+        metadata={"source": "test"},
+        chunks=[(0, "chunk body", {"start": 0, "end": 12, "token_count": 3})],
+        initial_delay=0.0,
+    )
+
+    diag = store.schema_diagnostics(refresh=True)
+    assert diag["ok"], diag["errors"]
+    tables = diag["tables"].get("pending_documents", {})
+    assert tables.get("job_id") == "TEXT"
+    assert tables.get("doc_hash") == "TEXT"
+    assert tables.get("sim_signature") == "TEXT"
+    assert tables.get("created_at") == "INTEGER"
+
+    conn = sqlite3.connect(store.path)
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT job_id, doc_hash, sim_signature, created_at FROM pending_documents WHERE doc_id = ?",
+            (doc_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row["job_id"] == big_job_id
+    assert row["doc_hash"] == doc_hash
+    assert row["sim_signature"] == str(sim_signature)
+    assert isinstance(row["created_at"], int)
+    assert 0 < row["created_at"] <= int(time.time())
+
+    pending = store.pop_pending_documents(limit=1)
+    assert pending and pending[0]["doc_id"] == doc_id
+    record = pending[0]
+    assert record["job_id"] == big_job_id
+    assert record["doc_hash"] == doc_hash
+    assert record["sim_signature"] == sim_signature
+    assert record["attempts"] == 0
+    assert record["chunks"] and record["chunks"][0]["text"] == "chunk body"


### PR DESCRIPTION
## Summary
- migrate pending vector tables to use TEXT identifiers and seconds timestamps with a schema guard
- add diagnostics endpoint, migration check script, and regression tests covering large IDs
- scaffold shadow crawl e2e, planner fallback, and focused crawl compatibility fixes

## Testing
- pytest -q
- scripts/check_migrations.sh

------
https://chatgpt.com/codex/tasks/task_e_68e5de9214dc83219227d3c045ac8a4e