### PR TITLE
Add mission control graph dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ diagnostics/*
 !backend/app/api/utils.py
 !backend/app/api/db.py
 !backend/app/api/embeddings.py
+!backend/app/api/graph_viz.py
 !backend/app/config/
 !backend/app/config/__init__.py
 !backend/app/config/models.py

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ make stop || true
 BACKEND_PORT=5050 make dev
 ```
 
+### Mission Control dashboard
+
+- Visit [http://localhost:3100/mission-control](http://localhost:3100/mission-control)
+  to explore the desert-themed "Mission Control" overview.
+- The page calls two backend APIs exposed by the Flask app:
+  - `/api/graph/network` – force-directed URL/link network.
+  - `/api/graph/hierarchy` – hierarchical site/topic data for treemap + radial
+    views.
+- When developing against a remote API, set `NEXT_PUBLIC_API_BASE_URL` in
+  `frontend/.env` (or your shell) so the frontend fetches from the correct
+  origin.
+
 ### Desktop development
 
 - Run `npm run dev:desktop` to launch the Flask API on `tcp://127.0.0.1:5050`, auto-detect an open renderer port (preferring `http://127.0.0.1:3100`), and open an Electron window pointed at the freshly spawned Next.js dev server. `detect-port` prevents collisions with stale runs, and `kill-port` guarantees the prior renderer is cleaned up before boot.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -105,6 +105,7 @@ def create_app() -> Flask:
     from .api import sources as sources_api
     from .api import runtime as runtime_api
     from .api import repo as repo_api
+    from .api import graph_viz as graph_viz_api
     from .api import embeddings as embeddings_api
     from .api import overview as overview_api
     try:
@@ -668,6 +669,7 @@ def create_app() -> Flask:
     app.register_blueprint(index_api.bp)
     app.register_blueprint(index_health_api.bp)
     app.register_blueprint(discovery_api.bp)
+    app.register_blueprint(graph_viz_api.bp)
     app.register_blueprint(embeddings_api.bp)
     app.register_blueprint(shadow_api.bp)
     app.register_blueprint(shipit_crawl_api.bp)

--- a/backend/app/api/graph_viz.py
+++ b/backend/app/api/graph_viz.py
@@ -1,0 +1,53 @@
+"""Mission Control graph endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, abort, current_app, jsonify, request
+
+from backend.app.db import AppStateDB
+
+
+bp = Blueprint("graph_viz", __name__, url_prefix="/api/graph")
+
+PALETTE = {
+    "seed": "#D35400",
+    "node": "#E67E22",
+    "edge": "#8D6E63",
+    "leaf": "#D7CCC8",
+}
+
+
+def _state_db() -> AppStateDB:
+    state_db = current_app.config.get("APP_STATE_DB")
+    if not isinstance(state_db, AppStateDB):
+        abort(500, "app state database unavailable")
+    return state_db
+
+
+@bp.get("/network")
+def get_network_snapshot():
+    limit = request.args.get("limit", type=int) or 2000
+    state_db = _state_db()
+    snapshot = state_db.graph_network_snapshot(limit=limit)
+
+    nodes = []
+    for node in snapshot.get("nodes", []):
+        color = node.get("color") or (PALETTE["node"] if node.get("val", 0) >= 4 else PALETTE["leaf"])
+        nodes.append({**node, "color": color})
+
+    links = [
+        {
+            **link,
+            "color": PALETTE["edge"],
+        }
+        for link in snapshot.get("links", [])
+    ]
+
+    return jsonify({"nodes": nodes, "links": links})
+
+
+@bp.get("/hierarchy")
+def get_hierarchy_snapshot():
+    state_db = _state_db()
+    hierarchy = state_db.graph_hierarchy_snapshot()
+    return jsonify(hierarchy)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@tanstack/react-query": "^5.90.7",
         "ai": "^5.0.89",
         "cmdk": "^1.1.1",
+        "d3": "^7.9.0",
         "dompurify": "^3.0.11",
         "highlight.js": "^11.10.0",
         "katex": "^0.16.11",
@@ -6546,6 +6547,47 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -6558,17 +6600,78 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-binarytree": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
       "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
       "license": "MIT"
     },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -6595,11 +6698,71 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -6624,6 +6787,27 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -6656,10 +6840,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
       "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7038,6 +7240,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -9745,7 +9956,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -14262,6 +14472,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.52.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
@@ -14334,6 +14550,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -14432,7 +14654,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@tanstack/react-query": "^5.90.7",
     "ai": "^5.0.89",
     "cmdk": "^1.1.1",
+    "d3": "^7.9.0",
     "dompurify": "^3.0.11",
     "highlight.js": "^11.10.0",
     "katex": "^0.16.11",

--- a/frontend/src/app/mission-control/page.tsx
+++ b/frontend/src/app/mission-control/page.tsx
@@ -1,0 +1,31 @@
+import { DesertNetwork } from "@/components/visualizations/DesertNetwork";
+import { DesertRadial } from "@/components/visualizations/DesertRadial";
+import { DesertVoronoi } from "@/components/visualizations/DesertVoronoi";
+
+export default function MissionControlPage() {
+  return (
+    <div className="min-h-screen w-full" style={{ background: "#FFF8F0" }}>
+      <div className="mx-auto max-w-7xl px-6 py-10">
+        <header className="mb-8 space-y-2 text-center md:text-left">
+          <p className="text-sm font-semibold uppercase tracking-wide" style={{ color: "#D35400" }}>
+            Mission Control
+          </p>
+          <h1 className="text-3xl font-bold" style={{ color: "#5D4037" }}>
+            Crawled Data Overview
+          </h1>
+          <p className="max-w-3xl text-lg" style={{ color: "#8D6E63" }}>
+            Visualizing the crawled index as a living network rooted in warm desert tones.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="lg:col-span-2">
+            <DesertNetwork />
+          </div>
+          <DesertVoronoi />
+          <DesertRadial />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/visualizations/DesertNetwork.tsx
+++ b/frontend/src/components/visualizations/DesertNetwork.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+
+import { api } from "@/lib/api";
+
+const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), { ssr: false });
+
+interface NetworkNode {
+  id: string;
+  name?: string;
+  group?: string | null;
+  val?: number;
+  color?: string;
+}
+
+interface NetworkLink {
+  source: string;
+  target: string;
+  color?: string;
+}
+
+interface NetworkResponse {
+  nodes: NetworkNode[];
+  links: NetworkLink[];
+}
+
+const CANVAS_BACKGROUND = "#F5E6D3";
+
+export function DesertNetwork() {
+  const [data, setData] = useState<NetworkResponse>({ nodes: [], links: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchData() {
+      try {
+        setLoading(true);
+        const response = await fetch(api("/api/graph/network"));
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+        const payload = (await response.json()) as NetworkResponse;
+        if (!cancelled) {
+          setData(payload);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Unable to load network");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sizedData = useMemo(() => {
+    return {
+      nodes: data.nodes.map((node) => ({ ...node, val: node.val ?? 4 })),
+      links: data.links,
+    };
+  }, [data]);
+
+  return (
+    <div className="rounded-xl border" style={{ borderColor: "#8D6E63", background: CANVAS_BACKGROUND }}>
+      <div className="flex items-center justify-between px-4 py-2">
+        <div>
+          <h2 className="text-lg font-semibold" style={{ color: "#5D4037" }}>
+            Living Root System
+          </h2>
+          <p className="text-sm" style={{ color: "#8D6E63" }}>
+            Force-directed view of URLs and their link structure.
+          </p>
+        </div>
+        {loading && <span className="text-sm" style={{ color: "#5D4037" }}>Loading...</span>}
+        {error && (
+          <span className="text-sm" style={{ color: "#D35400" }}>
+            {error}
+          </span>
+        )}
+      </div>
+      <div className="h-[520px] w-full">
+        <ForceGraph2D
+          graphData={sizedData}
+          backgroundColor={CANVAS_BACKGROUND}
+          nodeColor={(node) => (node as NetworkNode).color || "#E67E22"}
+          nodeLabel={(node) => (node as NetworkNode).name || (node as NetworkNode).id}
+          nodeRelSize={6}
+          linkColor={() => "#8D6E63"}
+          linkDirectionalParticles={2}
+          linkDirectionalParticleSpeed={0.005}
+          linkDirectionalParticleWidth={2}
+          linkDirectionalParticleColor={() => "#D35400"}
+          width={undefined}
+          height={undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/visualizations/DesertRadial.tsx
+++ b/frontend/src/components/visualizations/DesertRadial.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as d3 from "d3";
+
+import { api } from "@/lib/api";
+
+interface HierarchyNode {
+  name: string;
+  value?: number;
+  url?: string;
+  children?: HierarchyNode[];
+}
+
+export function DesertRadial() {
+  const [root, setRoot] = useState<HierarchyNode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [radius, setRadius] = useState(260);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        setLoading(true);
+        const resp = await fetch(api("/api/graph/hierarchy"));
+        if (!resp.ok) throw new Error(`Status ${resp.status}`);
+        const payload = (await resp.json()) as HierarchyNode;
+        if (!cancelled) {
+          setRoot(payload);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unable to load hierarchy");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    function updateSize() {
+      const el = containerRef.current;
+      if (!el) return;
+      const { width } = el.getBoundingClientRect();
+      setRadius(Math.max(180, Math.min(width / 2, 360)));
+    }
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  const clusterData = useMemo(() => {
+    if (!root) return null;
+    const hierarchy = d3.hierarchy(root);
+    const cluster = d3.cluster<HierarchyNode>().size([2 * Math.PI, radius - 60]);
+    return cluster(hierarchy);
+  }, [radius, root]);
+
+  const linkGenerator = useMemo(
+    () =>
+      d3
+        .linkRadial<d3.HierarchyPointNode<HierarchyNode>, d3.HierarchyPointNode<HierarchyNode>>()
+        .angle((d) => d.x)
+        .radius((d) => d.y),
+    []
+  );
+
+  const diameter = radius * 2;
+
+  return (
+    <div
+      ref={containerRef}
+      className="rounded-xl border p-4"
+      style={{ borderColor: "#8D6E63", background: "#F5E6D3" }}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold" style={{ color: "#5D4037" }}>
+            Crawl Depth (The Oasis)
+          </h3>
+          <p className="text-sm" style={{ color: "#8D6E63" }}>
+            Radial hierarchy of the crawled structure.
+          </p>
+        </div>
+        {loading && <span className="text-sm" style={{ color: "#5D4037" }}>Loading...</span>}
+        {error && (
+          <span className="text-sm" style={{ color: "#D35400" }}>
+            {error}
+          </span>
+        )}
+      </div>
+      <svg width={diameter} height={diameter}>
+        <g transform={`translate(${radius},${radius})`}>
+          {clusterData?.links().map((link, idx) => (
+            <path
+              key={`link-${idx}`}
+              d={linkGenerator(link) ?? undefined}
+              fill="none"
+              stroke="#8D6E63"
+              strokeWidth={1}
+              opacity={0.7}
+            />
+          ))}
+          {clusterData?.descendants().map((node, idx) => {
+            const isRoot = idx === 0;
+            const angle = (node.x * 180) / Math.PI;
+            const rotate = angle < 180 ? angle - 90 : angle + 90;
+            return (
+              <g key={`node-${idx}`} transform={`rotate(${(node.x * 180) / Math.PI - 90}) translate(${node.y},0)`}>
+                <circle
+                  r={isRoot ? 14 : 4}
+                  fill={isRoot ? "#00C853" : "#D35400"}
+                  stroke="#F5E6D3"
+                  strokeWidth={isRoot ? 2 : 1}
+                />
+                {!isRoot && (
+                  <text
+                    dy="0.31em"
+                    x={node.x < Math.PI === !node.children ? 8 : -8}
+                    textAnchor={node.x < Math.PI === !node.children ? "start" : "end"}
+                    transform={`rotate(${rotate})`}
+                    fontSize={11}
+                    fill="#4a342f"
+                  >
+                    {(node.data.name || "").slice(0, 30)}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/visualizations/DesertVoronoi.tsx
+++ b/frontend/src/components/visualizations/DesertVoronoi.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as d3 from "d3";
+
+import { api } from "@/lib/api";
+
+interface HierarchyNode {
+  name: string;
+  value?: number;
+  url?: string;
+  children?: HierarchyNode[];
+}
+
+const palette = ["#D35400", "#E67E22", "#A1887F", "#D7CCC8"];
+
+export function DesertVoronoi() {
+  const [root, setRoot] = useState<HierarchyNode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState<{ width: number; height: number }>({ width: 640, height: 420 });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        setLoading(true);
+        const resp = await fetch(api("/api/graph/hierarchy"));
+        if (!resp.ok) throw new Error(`Status ${resp.status}`);
+        const payload = (await resp.json()) as HierarchyNode;
+        if (!cancelled) {
+          setRoot(payload);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unable to load hierarchy");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    function updateSize() {
+      const el = containerRef.current;
+      if (!el) return;
+      const { width } = el.getBoundingClientRect();
+      setSize({ width: Math.max(320, width), height: 420 });
+    }
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  const treemapNodes = useMemo(() => {
+    if (!root) return [];
+    const hierarchy = d3
+      .hierarchy(root)
+      .sum((d) => d.value ?? 1)
+      .sort((a, b) => (b.value || 0) - (a.value || 0));
+    d3.treemap<HierarchyNode>().size([size.width, size.height]).padding(4)(hierarchy);
+    return hierarchy.leaves();
+  }, [root, size.height, size.width]);
+
+  const colorScale = useMemo(
+    () =>
+      d3
+        .scaleOrdinal<string, string>()
+        .domain(treemapNodes.map((n) => n.parent?.data.name || "unknown"))
+        .range(palette),
+    [treemapNodes]
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="rounded-xl border p-4"
+      style={{ borderColor: "#8D6E63", background: "#F5E6D3" }}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold" style={{ color: "#5D4037" }}>
+            Topic Distribution (Cracked Earth)
+          </h3>
+          <p className="text-sm" style={{ color: "#8D6E63" }}>
+            Treemap grouped by site/topic from indexed documents.
+          </p>
+        </div>
+        {loading && <span className="text-sm" style={{ color: "#5D4037" }}>Loading...</span>}
+        {error && (
+          <span className="text-sm" style={{ color: "#D35400" }}>
+            {error}
+          </span>
+        )}
+      </div>
+      <svg width={size.width} height={size.height}>
+        {treemapNodes.map((node, idx) => {
+          const fill = colorScale(node.parent?.data.name || "unknown");
+          const label = node.data.name.length > 24 ? `${node.data.name.slice(0, 24)}…` : node.data.name;
+          return (
+            <g key={`leaf-${idx}`} transform={`translate(${node.x0},${node.y0})`}>
+              <rect
+                width={Math.max(0, node.x1 - node.x0)}
+                height={Math.max(0, node.y1 - node.y0)}
+                fill={fill}
+                stroke="#5D4037"
+                rx={6}
+                opacity={0.9}
+              />
+              <text x={8} y={18} fontSize={12} fill="#2d1e19" fontWeight={600} pointerEvents="none">
+                {label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Flask graph endpoints for network and hierarchy visualizations with desert color palette defaults
- build Mission Control page with force graph, treemap, and radial hierarchy components
- document new dashboard route and ensure frontend pulls data from API base URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd4b899c08321b158526931e70ecf)